### PR TITLE
Update header title to 'Control Horari Educació'

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,7 @@ export function Header({ config, onOpenSettings }: HeaderProps) {
               <Clock className="w-6 h-6 text-primary-foreground" />
             </div>
             <div>
-              <h1 className="text-xl font-bold text-foreground">Control Horari</h1>
+              <h1 className="text-xl font-bold text-foreground">Control Horari Educació</h1>
               <p className="text-sm text-muted-foreground">
                 {userName} · Any 2026
               </p>


### PR DESCRIPTION
### Motivation
- Change the displayed header title from `Control Horari` to `Control Horari Educació` to reflect the education variant.

### Description
- Update `src/components/Header.tsx` to replace the `<h1>` text with `Control Horari Educació`.

### Testing
- No automated tests were executed; an attempt to run `npm install` was started but was interrupted and did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5fb708a08327a38db96232dafa88)