### PR TITLE
Persist cleared start/end times and update header title

### DIFF
--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -32,8 +32,8 @@ export function DayDetailDialog({ date, dayData, config, onClose, onSave }: DayD
 
   useEffect(() => {
     if (dayData) {
-      setStartTime(dayData.startTime || config.defaultStartTime);
-      setEndTime(dayData.endTime || config.defaultEndTime);
+      setStartTime(dayData.startTime === null ? '' : (dayData.startTime ?? config.defaultStartTime));
+      setEndTime(dayData.endTime === null ? '' : (dayData.endTime ?? config.defaultEndTime));
       
       // Determine absence type from dayStatus
       if (dayData.dayStatus === 'vacances') {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,7 @@ export function Header({ config, onOpenSettings }: HeaderProps) {
               <Clock className="w-6 h-6 text-primary-foreground" />
             </div>
             <div>
-              <h1 className="text-xl font-bold text-foreground">Control Horari</h1>
+              <h1 className="text-xl font-bold text-foreground">Control Horari Educació</h1>
               <p className="text-sm text-muted-foreground">
                 {userName} · Any 2026
               </p>


### PR DESCRIPTION
### Motivation
- Preserve user-cleared start/end times so that deleting times with the trash button remains cleared when reopening the day dialog instead of being refilled with defaults.
- Update the app header to reflect the education variant by changing the displayed title.

### Description
- Treat `dayData.startTime === null` and `dayData.endTime === null` as intentionally cleared values and initialize the component state to an empty string in `src/components/Calendar/DayDetailDialog.tsx` so cleared times persist when reopening the dialog.
- Keep existing save logic that maps empty `startTime`/`endTime` back to `null`, so cleared values are stored and reused correctly.
- Change the header text in `src/components/Header.tsx` from `Control Horari` to `Control Horari Educació`.

### Testing
- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5fb708a08327a38db96232dafa88)