### PR TITLE
Refine schedule period handling for 2026 coverage

### DIFF
--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -32,8 +32,8 @@ export function DayDetailDialog({ date, dayData, config, onClose, onSave }: DayD
 
   useEffect(() => {
     if (dayData) {
-      setStartTime(dayData.startTime || config.defaultStartTime);
-      setEndTime(dayData.endTime || config.defaultEndTime);
+      setStartTime(dayData.startTime === null ? '' : (dayData.startTime ?? config.defaultStartTime));
+      setEndTime(dayData.endTime === null ? '' : (dayData.endTime ?? config.defaultEndTime));
       
       // Determine absence type from dayStatus
       if (dayData.dayStatus === 'vacances') {

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,7 +21,7 @@ export function Header({ config, onOpenSettings }: HeaderProps) {
               <Clock className="w-6 h-6 text-primary-foreground" />
             </div>
             <div>
-              <h1 className="text-xl font-bold text-foreground">Control Horari</h1>
+              <h1 className="text-xl font-bold text-foreground">Control Horari Educació</h1>
               <p className="text-sm text-muted-foreground">
                 {userName} · Any 2026
               </p>


### PR DESCRIPTION
### Motivation
- Ensure the schedule UI always covers the full year 2026 so every day is assigned to either `estiu` or `hivern` without gaps.
- Lock the initial start of the first period to `2026-01-01` and auto-create the complementary period so users only need to adjust the split date/type.
- Preserve deliberate user clears of start/end times in the day dialog so emptied times stay empty when reopening the dialog.
- Reflect the education variant in the app header title.

### Description
- Added `normalizeSchedulePeriods` in `src/components/Settings/SettingsDialog.tsx` to enforce a primary period starting at `2026-01-01` and to auto-create a complementary period that covers the remainder of 2026 with the opposite `scheduleType`. 
- Switched `validateScheduleCoverage` to accept a list of `SchedulePeriod` and run validation against the normalized periods, and updated `handleSave` to save `schedulePeriods: sortedSchedulePeriods` so the normalized coverage is persisted. 
- Removed manual add/remove period controls and `newPeriod` state, and disabled editing of the primary start date and secondary rows in the settings UI so the second row is derived automatically. 
- Simplified `updateSchedulePeriod` to apply edits then re-normalize the periods with `normalizeSchedulePeriods` before writing into `localConfig`. 
- Treated cleared times as intentional in `src/components/Calendar/DayDetailDialog.tsx` by mapping `dayData.startTime === null` / `dayData.endTime === null` to `''` so cleared fields persist when reopening the dialog. 
- Updated header text in `src/components/Header.tsx` from `Control Horari` to `Control Horari Educació`.

### Testing
- Attempted to install dependencies and run tests, but `npm install` failed with a `403 Forbidden` from the registry so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e5fb708a08327a38db96232dafa88)