### PR TITLE
Allow multiple summer/winter schedule periods

### DIFF
--- a/src/lib/timeCalculations.ts
+++ b/src/lib/timeCalculations.ts
@@ -33,7 +33,9 @@ export function getDayOfWeekKey(date: Date): keyof WeeklyConfig | null {
 }
 
 export function getScheduleTypeForDate(date: Date, config: UserConfig): ScheduleType | null {
-  const periods = config.schedulePeriods || [];
+  const periods = [...(config.schedulePeriods || [])].sort(
+    (a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime()
+  );
   for (const period of periods) {
     const start = parseISO(period.startDate);
     const end = parseISO(period.endDate);


### PR DESCRIPTION
### Motivation
- Users need the ability to define more than two schedule periods (Estiu/Hivern) across the year instead of the previous two-period normalization.

### Description
- Removed the previous two-period normalization and instead sort and preserve arbitrary `schedulePeriods` using a new `sortSchedulePeriods` helper.
- Added UI actions `addSchedulePeriod` and `removeSchedulePeriod`, a button to add periods, and per-period delete buttons in `SettingsDialog.tsx`, and made period date inputs editable with basic start/end date correction.
- Updated `updateSchedulePeriod` to stop forcing an opposite counterpart and to keep periods sorted after edits (`updateSchedulePeriod`, `addSchedulePeriod`, `removeSchedulePeriod`).
- Ensured schedule lookup is stable by sorting periods before searching in `getScheduleTypeForDate` in `src/lib/timeCalculations.ts`.

### Testing
- No automated tests were executed because `npm install` failed due to a `403 Forbidden` from the npm registry, so build/tests could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e6eaed26083279bd2b6d1917865cd)