### PR TITLE
Condense status summary cards

### DIFF
--- a/src/components/Summary/StatusSummary.tsx
+++ b/src/components/Summary/StatusSummary.tsx
@@ -15,59 +15,65 @@ export function StatusSummary({ config }: StatusSummaryProps) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       <Card>
-        <CardHeader className="pb-2">
+        <CardHeader className="pb-1">
           <CardTitle className="text-sm font-medium flex items-center gap-2">
             <Plane className="w-4 h-4 text-[hsl(var(--status-vacation))]" />
             Vacances
           </CardTitle>
         </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
+        <CardContent className="pt-0">
+          <div className="text-2xl font-bold leading-tight">
             {config.totalVacationDays - config.usedVacationDays}
             <span className="text-sm font-normal text-muted-foreground"> dies disponibles</span>
           </div>
-          <Progress value={vacationProgress} className="mt-2 h-2" />
-          <p className="text-xs text-muted-foreground mt-1">
-            {config.usedVacationDays} de {config.totalVacationDays} dies utilitzats
-          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <Progress value={vacationProgress} className="h-2 flex-1" />
+            <p className="text-xs text-muted-foreground whitespace-nowrap">
+              {config.usedVacationDays} de {config.totalVacationDays} dies utilitzats
+            </p>
+          </div>
         </CardContent>
       </Card>
 
       <Card>
-        <CardHeader className="pb-2">
+        <CardHeader className="pb-1">
           <CardTitle className="text-sm font-medium flex items-center gap-2">
             <Clock className="w-4 h-4 text-primary" />
             Assumptes Propis
           </CardTitle>
         </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
+        <CardContent className="pt-0">
+          <div className="text-2xl font-bold leading-tight">
             {(config.totalAPHours - config.usedAPHours).toFixed(1)}
             <span className="text-sm font-normal text-muted-foreground"> hores disponibles</span>
           </div>
-          <Progress value={apProgress} className="mt-2 h-2" />
-          <p className="text-xs text-muted-foreground mt-1">
-            {config.usedAPHours.toFixed(1)} de {config.totalAPHours} hores utilitzades
-          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <Progress value={apProgress} className="h-2 flex-1" />
+            <p className="text-xs text-muted-foreground whitespace-nowrap">
+              {config.usedAPHours.toFixed(1)} de {config.totalAPHours} hores utilitzades
+            </p>
+          </div>
         </CardContent>
       </Card>
 
       <Card>
-        <CardHeader className="pb-2">
+        <CardHeader className="pb-1">
           <CardTitle className="text-sm font-medium flex items-center gap-2">
             <Sparkles className="w-4 h-4 text-[hsl(var(--status-complete))]" />
             Flexibilitat Horària
           </CardTitle>
         </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
+        <CardContent className="pt-0">
+          <div className="text-2xl font-bold leading-tight">
             {config.flexibilityHours.toFixed(1)}
             <span className="text-sm font-normal text-muted-foreground"> hores acumulades</span>
           </div>
-          <Progress value={flexProgress} className="mt-2 h-2" />
-          <p className="text-xs text-muted-foreground mt-1">
-            Màxim 25 hores acumulables
-          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <Progress value={flexProgress} className="h-2 flex-1" />
+            <p className="text-xs text-muted-foreground whitespace-nowrap">
+              Màxim 25 hores acumulables
+            </p>
+          </div>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
### Motivation
- Reduce the vertical height of the status summary cards so the summary occupies less vertical space and fits in two lines visually.

### Description
- Tighten header padding by changing `CardHeader` from `pb-2` to `pb-1` for each summary card in `src/components/Summary/StatusSummary.tsx`.
- Remove top padding on content by adding `className="pt-0"` to `CardContent` and add `leading-tight` to the main value text to reduce line height.
- Move the `Progress` bar and usage text into a single horizontal row using a wrapper `div` with `mt-2 flex items-center gap-2`, make progress expand with `flex-1`, and keep usage text on one line with `whitespace-nowrap`.
- Applied the changes to all three cards: Vacances, Assumptes Propis, and Flexibilitat Horària.

### Testing
- Attempted to install dependencies with `npm install`, which failed due to a `403 Forbidden` error from the npm registry, so the dev server and automated test suite could not be run.
- No automated tests were executed because dependency installation was blocked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e70ca12a48327badd904bfd58dfbf)