### PR TITLE
Place summary values inline with titles and move progress bars under headers

### DIFF
--- a/src/components/Summary/StatusSummary.tsx
+++ b/src/components/Summary/StatusSummary.tsx
@@ -16,17 +16,19 @@ export function StatusSummary({ config }: StatusSummaryProps) {
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium flex items-center gap-2">
-            <Plane className="w-4 h-4 text-[hsl(var(--status-vacation))]" />
-            Vacances
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
-            {config.totalVacationDays - config.usedVacationDays}
-            <span className="text-sm font-normal text-muted-foreground"> dies disponibles</span>
+          <div className="flex items-center justify-between gap-4">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Plane className="w-4 h-4 text-[hsl(var(--status-vacation))]" />
+              Vacances
+            </CardTitle>
+            <div className="text-base font-semibold">
+              {config.totalVacationDays - config.usedVacationDays}
+              <span className="text-sm font-normal text-muted-foreground"> dies disponibles</span>
+            </div>
           </div>
-          <Progress value={vacationProgress} className="mt-2 h-2" />
+        </CardHeader>
+        <CardContent className="pt-0">
+          <Progress value={vacationProgress} className="h-2" />
           <p className="text-xs text-muted-foreground mt-1">
             {config.usedVacationDays} de {config.totalVacationDays} dies utilitzats
           </p>
@@ -35,17 +37,19 @@ export function StatusSummary({ config }: StatusSummaryProps) {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium flex items-center gap-2">
-            <Clock className="w-4 h-4 text-primary" />
-            Assumptes Propis
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
-            {(config.totalAPHours - config.usedAPHours).toFixed(1)}
-            <span className="text-sm font-normal text-muted-foreground"> hores disponibles</span>
+          <div className="flex items-center justify-between gap-4">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Clock className="w-4 h-4 text-primary" />
+              Assumptes Propis
+            </CardTitle>
+            <div className="text-base font-semibold">
+              {(config.totalAPHours - config.usedAPHours).toFixed(1)}
+              <span className="text-sm font-normal text-muted-foreground"> hores disponibles</span>
+            </div>
           </div>
-          <Progress value={apProgress} className="mt-2 h-2" />
+        </CardHeader>
+        <CardContent className="pt-0">
+          <Progress value={apProgress} className="h-2" />
           <p className="text-xs text-muted-foreground mt-1">
             {config.usedAPHours.toFixed(1)} de {config.totalAPHours} hores utilitzades
           </p>
@@ -54,17 +58,19 @@ export function StatusSummary({ config }: StatusSummaryProps) {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium flex items-center gap-2">
-            <Sparkles className="w-4 h-4 text-[hsl(var(--status-complete))]" />
-            Flexibilitat Horària
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
-            {config.flexibilityHours.toFixed(1)}
-            <span className="text-sm font-normal text-muted-foreground"> hores acumulades</span>
+          <div className="flex items-center justify-between gap-4">
+            <CardTitle className="text-sm font-medium flex items-center gap-2">
+              <Sparkles className="w-4 h-4 text-[hsl(var(--status-complete))]" />
+              Flexibilitat Horària
+            </CardTitle>
+            <div className="text-base font-semibold">
+              {config.flexibilityHours.toFixed(1)}
+              <span className="text-sm font-normal text-muted-foreground"> hores acumulades</span>
+            </div>
           </div>
-          <Progress value={flexProgress} className="mt-2 h-2" />
+        </CardHeader>
+        <CardContent className="pt-0">
+          <Progress value={flexProgress} className="h-2" />
           <p className="text-xs text-muted-foreground mt-1">
             Màxim 25 hores acumulables
           </p>


### PR DESCRIPTION
### Motivation
- Align numeric summary values (e.g. "25 dies disponibles") on the same header line as their labels to reduce vertical height for the Vacances, Assumptes Propis, and Flexibilitat Horària cards. 
- Move the progress bar and its caption beneath the header so the header row remains single-line and the card content is more compact.

### Description
- Update `src/components/Summary/StatusSummary.tsx` to wrap `CardTitle` and the numeric value in a `div` with `flex items-center justify-between` so the value appears inline with the label. 
- Move the `Progress` component and its caption into `CardContent` underneath the header and use `className="h-2"` for the bars while setting `CardContent` to `pt-0` and `CardHeader` to `pb-2`. 
- Apply the same layout changes to all three cards: Vacances, Assumptes Propis, and Flexibilitat Horària.

### Testing
- No automated tests were run because dependency installation and the dev server were not executed due to registry access constraints, so there are no test results to report.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e70ca12a48327badd904bfd58dfbf)