### PR TITLE
Weekly summary: read-only per-day cards with daily differences and exclude vacations/holidays

### DIFF
--- a/src/components/Calendar/CalendarGrid.tsx
+++ b/src/components/Calendar/CalendarGrid.tsx
@@ -149,7 +149,6 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
         daysData={daysData}
         config={config}
         onClose={() => setSelectedWeek(null)}
-        onSaveDay={onDayUpdate}
       />
     </div>
   );

--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -1,13 +1,9 @@
-import { useState, useEffect } from 'react';
 import { format, eachDayOfInterval, getWeek } from 'date-fns';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
-import type { DayData, UserConfig, DayStatus, RequestStatus } from '@/types';
+import type { DayData, UserConfig } from '@/types';
 import { 
   getTheoreticalHoursForDate, 
   getDayTypeForDate, 
@@ -17,7 +13,7 @@ import {
   formatHoursDisplay 
 } from '@/lib/timeCalculations';
 import { DAY_NAMES_CA, MONTH_NAMES_CA } from '@/lib/constants';
-import { Home, Building2, Plane, Clock, Sparkles, Calendar } from 'lucide-react';
+import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check } from 'lucide-react';
 
 interface WeeklySummaryDialogProps {
   weekStart: Date | null;
@@ -25,16 +21,6 @@ interface WeeklySummaryDialogProps {
   daysData: Record<string, DayData>;
   config: UserConfig;
   onClose: () => void;
-  onSaveDay: (dayData: DayData) => void;
-}
-
-interface DayEditState {
-  startTime: string;
-  endTime: string;
-  dayStatus: DayStatus;
-  requestStatus: RequestStatus;
-  apHours: number;
-  flexHours: number;
 }
 
 export function WeeklySummaryDialog({ 
@@ -42,36 +28,8 @@ export function WeeklySummaryDialog({
   weekEnd, 
   daysData, 
   config, 
-  onClose, 
-  onSaveDay 
+  onClose
 }: WeeklySummaryDialogProps) {
-  const [editStates, setEditStates] = useState<Record<string, DayEditState>>({});
-  
-  useEffect(() => {
-    if (!weekStart || !weekEnd) return;
-    
-    const days = eachDayOfInterval({ start: weekStart, end: weekEnd });
-    const newStates: Record<string, DayEditState> = {};
-    
-    for (const day of days) {
-      if (isWeekend(day)) continue;
-      
-      const dateStr = format(day, 'yyyy-MM-dd');
-      const dayData = daysData[dateStr];
-      
-      newStates[dateStr] = {
-        startTime: dayData?.startTime || config.defaultStartTime,
-        endTime: dayData?.endTime || config.defaultEndTime,
-        dayStatus: dayData?.dayStatus || 'laboral',
-        requestStatus: dayData?.requestStatus || null,
-        apHours: dayData?.apHours || 0,
-        flexHours: dayData?.flexHours || 0,
-      };
-    }
-    
-    setEditStates(newStates);
-  }, [weekStart, weekEnd, daysData, config]);
-
   if (!weekStart || !weekEnd) return null;
 
   const days = eachDayOfInterval({ start: weekStart, end: weekEnd });
@@ -83,44 +41,6 @@ export function WeeklySummaryDialog({
     return DAY_NAMES_CA[dayKeys[dayIndex]];
   };
 
-  const updateDayState = (dateStr: string, field: keyof DayEditState, value: any) => {
-    setEditStates(prev => ({
-      ...prev,
-      [dateStr]: {
-        ...prev[dateStr],
-        [field]: value,
-      }
-    }));
-  };
-
-  const handleSaveAll = () => {
-    for (const day of days) {
-      if (isWeekend(day)) continue;
-      
-      const dateStr = format(day, 'yyyy-MM-dd');
-      const state = editStates[dateStr];
-      if (!state) continue;
-      
-      const theoreticalHours = getTheoreticalHoursForDate(day, config);
-      const dayType = getDayTypeForDate(day, config);
-      
-      const newDayData: DayData = {
-        date: dateStr,
-        theoreticalHours,
-        startTime: state.dayStatus === 'vacances' ? null : state.startTime,
-        endTime: state.dayStatus === 'vacances' ? null : state.endTime,
-        dayType,
-        dayStatus: state.dayStatus,
-        requestStatus: state.requestStatus,
-        apHours: state.dayStatus === 'assumpte_propi' ? state.apHours : undefined,
-        flexHours: state.dayStatus === 'flexibilitat' ? state.flexHours : undefined,
-      };
-      
-      onSaveDay(newDayData);
-    }
-    onClose();
-  };
-
   // Calculate weekly totals
   let totalTheoretical = 0;
   let totalWorked = 0;
@@ -129,24 +49,59 @@ export function WeeklySummaryDialog({
     if (isWeekend(day) || isHoliday(day, config.holidays)) continue;
     
     const dateStr = format(day, 'yyyy-MM-dd');
-    const state = editStates[dateStr];
-    if (!state) continue;
-    
+    const dayData = daysData[dateStr];
+    if (dayData?.dayStatus === 'vacances') continue;
+
     const theoretical = getTheoreticalHoursForDate(day, config);
     totalTheoretical += theoretical;
     
-    if (state.dayStatus === 'vacances') {
-      totalWorked += theoretical;
-    } else if (state.dayStatus === 'assumpte_propi') {
-      totalWorked += (state.apHours || 0) + calculateWorkedHours(state.startTime, state.endTime);
-    } else if (state.dayStatus === 'flexibilitat') {
-      totalWorked += (state.flexHours || 0) + calculateWorkedHours(state.startTime, state.endTime);
+    if (dayData?.dayStatus === 'assumpte_propi') {
+      totalWorked += (dayData.apHours || 0) + calculateWorkedHours(dayData.startTime, dayData.endTime);
+    } else if (dayData?.dayStatus === 'flexibilitat') {
+      totalWorked += (dayData.flexHours || 0) + calculateWorkedHours(dayData.startTime, dayData.endTime);
     } else {
-      totalWorked += calculateWorkedHours(state.startTime, state.endTime);
+      totalWorked += calculateWorkedHours(dayData?.startTime || null, dayData?.endTime || null);
     }
   }
 
   const difference = totalWorked - totalTheoretical;
+
+  const getDayStatusLabel = (dayData: DayData | undefined, holiday: boolean) => {
+    if (holiday) return 'Festiu';
+    if (!dayData) return 'Laboral';
+    if (dayData.dayStatus === 'vacances') return 'Vacances';
+    if (dayData.dayStatus === 'assumpte_propi') return 'AP';
+    if (dayData.dayStatus === 'flexibilitat') return 'FX';
+    return 'Laboral';
+  };
+
+  const getDayStatusIcon = (dayData: DayData | undefined, holiday: boolean) => {
+    if (holiday) return Calendar;
+    if (dayData?.dayStatus === 'vacances') return Plane;
+    if (dayData?.dayStatus === 'assumpte_propi') return Clock;
+    if (dayData?.dayStatus === 'flexibilitat') return Sparkles;
+    return null;
+  };
+
+  const getStatusCardClass = (dayData: DayData | undefined, holiday: boolean, worked: number, theoretical: number) => {
+    if (holiday) return 'bg-[hsl(var(--status-holiday)/0.15)] border-[hsl(var(--status-holiday)/0.4)]';
+    if (dayData?.dayStatus === 'vacances') {
+      return 'bg-[hsl(var(--status-vacation)/0.15)] border-[hsl(var(--status-vacation)/0.4)]';
+    }
+    if (dayData?.dayStatus === 'assumpte_propi' || dayData?.dayStatus === 'flexibilitat') {
+      return dayData?.requestStatus === 'aprovat'
+        ? 'bg-[hsl(var(--status-complete)/0.15)] border-[hsl(var(--status-complete)/0.4)]'
+        : 'bg-[hsl(var(--status-deficit)/0.15)] border-[hsl(var(--status-deficit)/0.4)]';
+    }
+    if (!dayData?.startTime || !dayData?.endTime) {
+      return 'bg-[hsl(var(--status-weekday-empty)/0.4)] border-[hsl(var(--status-weekday-empty))]';
+    }
+    return worked >= theoretical
+      ? 'bg-[hsl(var(--status-complete)/0.15)] border-[hsl(var(--status-complete)/0.4)]'
+      : 'bg-[hsl(var(--status-deficit)/0.15)] border-[hsl(var(--status-deficit)/0.4)]';
+  };
+
+  const formatHours = (hours: number) => `${hours.toFixed(1)}h`;
 
   return (
     <Dialog open={!!weekStart} onOpenChange={() => onClose()}>
@@ -165,122 +120,84 @@ export function WeeklySummaryDialog({
             if (isWeekend(day)) return null;
             
             const dateStr = format(day, 'yyyy-MM-dd');
-            const state = editStates[dateStr];
-            if (!state) return null;
-            
+            const dayData = daysData[dateStr];
             const holiday = isHoliday(day, config.holidays);
             const dayType = getDayTypeForDate(day, config);
             const theoretical = getTheoreticalHoursForDate(day, config);
-            const worked = state.dayStatus === 'vacances' 
-              ? theoretical 
-              : calculateWorkedHours(state.startTime, state.endTime);
+            const baseWorked = calculateWorkedHours(dayData?.startTime || null, dayData?.endTime || null);
+            const extraHours = dayData?.dayStatus === 'assumpte_propi'
+              ? (dayData.apHours || 0)
+              : dayData?.dayStatus === 'flexibilitat'
+                ? (dayData.flexHours || 0)
+                : 0;
+            const worked = baseWorked + extraHours;
+            const excludedFromTotals = holiday || dayData?.dayStatus === 'vacances';
+            const summaryTheoretical = excludedFromTotals ? 0 : theoretical;
+            const summaryWorked = excludedFromTotals ? 0 : worked;
+            const dayDifference = summaryWorked - summaryTheoretical;
             const DayIcon = dayType === 'teletreball' ? Home : Building2;
+            const StatusIcon = getDayStatusIcon(dayData, holiday);
+            const statusLabel = getDayStatusLabel(dayData, holiday);
+            const statusCardClass = getStatusCardClass(dayData, holiday, worked, theoretical);
             
             return (
-              <div key={dateStr} className="p-4 bg-muted/50 rounded-lg space-y-3">
+              <div
+                key={dateStr}
+                className={`p-4 rounded-lg space-y-4 border ${statusCardClass}`}
+              >
                 <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-2 flex-wrap">
                     <span className="font-semibold">{getDayName(day)}, {format(day, 'd')}</span>
                     <Badge variant={dayType === 'presencial' ? 'default' : 'secondary'} className="text-xs">
                       <DayIcon className="w-3 h-3 mr-1" />
                       {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
                     </Badge>
-                    {holiday && <Badge variant="destructive">Festiu</Badge>}
+                    <Badge variant="outline" className="text-xs flex items-center gap-1">
+                      {StatusIcon && <StatusIcon className="w-3 h-3" />}
+                      {statusLabel}
+                    </Badge>
+                    {dayData?.requestStatus === 'aprovat' && (
+                      <Badge variant="outline" className="text-xs flex items-center gap-1">
+                        <Check className="w-3 h-3" />
+                        Aprovat
+                      </Badge>
+                    )}
+                    {excludedFromTotals && (
+                      <Badge variant="secondary" className="text-xs">
+                        No computa
+                      </Badge>
+                    )}
                   </div>
-                  <Badge variant="outline">{theoretical}h teòriques</Badge>
+                  <Badge variant="outline">{formatHours(summaryTheoretical)} teòriques</Badge>
                 </div>
                 
-                {!holiday && (
-                  <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                    <div className="space-y-1">
-                      <Label className="text-xs">Tipus</Label>
-                      <Select 
-                        value={state.dayStatus} 
-                        onValueChange={(v) => updateDayState(dateStr, 'dayStatus', v)}
-                      >
-                        <SelectTrigger className="h-8">
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="laboral">Laboral</SelectItem>
-                          <SelectItem value="vacances">Vacances</SelectItem>
-                          <SelectItem value="assumpte_propi">AP</SelectItem>
-                          <SelectItem value="flexibilitat">FX</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-                    
-                    {state.dayStatus !== 'vacances' && (
-                      <>
-                        <div className="space-y-1">
-                          <Label className="text-xs">Inici</Label>
-                          <Input
-                            type="time"
-                            value={state.startTime}
-                            onChange={(e) => updateDayState(dateStr, 'startTime', e.target.value)}
-                            className="h-8"
-                          />
-                        </div>
-                        <div className="space-y-1">
-                          <Label className="text-xs">Fi</Label>
-                          <Input
-                            type="time"
-                            value={state.endTime}
-                            onChange={(e) => updateDayState(dateStr, 'endTime', e.target.value)}
-                            className="h-8"
-                          />
-                        </div>
-                      </>
-                    )}
-                    
-                    {(state.dayStatus === 'vacances' || state.dayStatus === 'assumpte_propi' || state.dayStatus === 'flexibilitat') && (
-                      <div className="space-y-1">
-                        <Label className="text-xs">Estat</Label>
-                        <Select 
-                          value={state.requestStatus || 'none'} 
-                          onValueChange={(v) => updateDayState(dateStr, 'requestStatus', v === 'none' ? null : v)}
-                        >
-                          <SelectTrigger className="h-8">
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value="none">Sense sol·licitar</SelectItem>
-                            <SelectItem value="pendent">Pendent</SelectItem>
-                            <SelectItem value="aprovat">Aprovat</SelectItem>
-                          </SelectContent>
-                        </Select>
-                      </div>
-                    )}
-                    
-                    {state.dayStatus === 'assumpte_propi' && (
-                      <div className="space-y-1">
-                        <Label className="text-xs">Hores AP</Label>
-                        <Input
-                          type="number"
-                          step="0.5"
-                          min="0"
-                          value={state.apHours}
-                          onChange={(e) => updateDayState(dateStr, 'apHours', parseFloat(e.target.value) || 0)}
-                          className="h-8"
-                        />
-                      </div>
-                    )}
-                    
-                    {state.dayStatus === 'flexibilitat' && (
-                      <div className="space-y-1">
-                        <Label className="text-xs">Hores FX</Label>
-                        <Input
-                          type="number"
-                          step="0.5"
-                          min="0"
-                          value={state.flexHours}
-                          onChange={(e) => updateDayState(dateStr, 'flexHours', parseFloat(e.target.value) || 0)}
-                          className="h-8"
-                        />
-                      </div>
+                <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
+                  <div className="space-y-1">
+                    <p className="text-muted-foreground">Horari</p>
+                    {holiday || dayData?.dayStatus === 'vacances' ? (
+                      <p className="font-medium">—</p>
+                    ) : dayData?.startTime && dayData?.endTime ? (
+                      <p className="font-medium">{dayData.startTime} - {dayData.endTime}</p>
+                    ) : (
+                      <p className="font-medium text-muted-foreground">Sense horari</p>
                     )}
                   </div>
-                )}
+                  <div className="space-y-1">
+                    <p className="text-muted-foreground">Hores treballades</p>
+                    <p className="font-medium">{formatHours(summaryWorked)}</p>
+                    {extraHours > 0 && (
+                      <p className="text-xs text-muted-foreground">
+                        +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
+                      </p>
+                    )}
+                  </div>
+                  <div className="space-y-1">
+                    <p className="text-muted-foreground">Diferència</p>
+                    <p className={`font-semibold ${dayDifference >= 0 ? 'text-[hsl(var(--status-complete))]' : 'text-[hsl(var(--status-deficit))]'}`}>
+                      {formatHoursDisplay(dayDifference)}
+                    </p>
+                  </div>
+                </div>
               </div>
             );
           })}
@@ -308,11 +225,8 @@ export function WeeklySummaryDialog({
         </div>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose}>
-            Cancel·lar
-          </Button>
-          <Button onClick={handleSaveAll}>
-            Desar tot
+          <Button onClick={onClose}>
+            Tancar
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/lib/timeCalculations.ts
+++ b/src/lib/timeCalculations.ts
@@ -92,12 +92,14 @@ export function calculateWeeklySummary(
     }
     
     const theoretical = getTheoreticalHoursForDate(day, config);
+    if (dayData?.dayStatus === 'vacances') {
+      return;
+    }
+    
     theoreticalHours += theoretical;
     
     if (dayData) {
-      if (dayData.dayStatus === 'vacances') {
-        workedHours += theoretical;
-      } else if (dayData.dayStatus === 'assumpte_propi') {
+      if (dayData.dayStatus === 'assumpte_propi') {
         workedHours += (dayData.apHours || 0) + calculateWorkedHours(dayData.startTime, dayData.endTime);
       } else if (dayData.dayStatus === 'flexibilitat') {
         workedHours += (dayData.flexHours || 0) + calculateWorkedHours(dayData.startTime, dayData.endTime);


### PR DESCRIPTION
### Motivation
- Convert the weekly summary into a non-editable, informational view that shows each day's worked vs theoretical hours with the appropriate status colors and icons.
- Ensure holidays and vacation days do not contribute to weekly theoretical/worked totals, and show the difference per day as requested.

### Description
- Replace the editable weekly dialog with a read-only view in `src/components/Calendar/WeeklySummaryDialog.tsx` that renders one status card per weekday containing day type, icons, worked hours, theoretical hours and the per-day `Diferència` badge, and update the dialog footer to a close-only action (`Tancar`).
- Remove the in-dialog edit state and the `onSaveDay` flow by deleting inputs/selects and the save handler, and remove the `onSaveDay` prop usage from `src/components/Calendar/CalendarGrid.tsx`.
- Compute per-day worked hours including `assumpte_propi` (AP) and `flexibilitat` (FX) extras and mark days that should be excluded from totals (holidays or `vacances`), displaying a `No computa` badge when appropriate in the dialog.
- Update `calculateWeeklySummary` in `src/lib/timeCalculations.ts` to exclude `vacances` days from both theoretical and worked totals so weekly totals/difference ignore those days.

### Testing
- No automated test suite was run in this environment because `npm install` failed with a registry `403` and the dev server could not start (`vite: not found`), so visual/manual verification was not performed.
- Linting/build checks were not executed due to missing dependencies in the runtime environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e761d26208327b0d024c3834baf18)