### PR TITLE
Recalculate weekly FX accumulation and cap FX requests to available balance

### DIFF
--- a/src/hooks/useTimeTracking.ts
+++ b/src/hooks/useTimeTracking.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import type { UserConfig, DayData } from '@/types';
 import { getUserConfig, saveUserConfig, getDaysData, saveDayData } from '@/lib/storage';
-import { DEFAULT_USER_CONFIG } from '@/lib/constants';
-import { calculateWorkedHours, getTheoreticalHoursForDate, calculateWeeklySummary } from '@/lib/timeCalculations';
+import { DEFAULT_USER_CONFIG, MAX_FLEXIBILITY_HOURS, MIN_WEEKLY_SURPLUS_FOR_FLEXIBILITY } from '@/lib/constants';
+import { calculateWeeklySummary } from '@/lib/timeCalculations';
 import { startOfWeek } from 'date-fns';
 
 export function useTimeTracking() {
@@ -26,14 +26,13 @@ export function useTimeTracking() {
   }, []);
 
   const updateDayData = useCallback((dayData: DayData) => {
-    const previousDayData = previousDaysDataRef.current[dayData.date];
-    
-    setDaysData(prev => {
-      const updated = { ...prev, [dayData.date]: dayData };
-      saveDayData(dayData);
-      previousDaysDataRef.current = updated;
-      return updated;
-    });
+    const previousDaysData = previousDaysDataRef.current;
+    const previousDayData = previousDaysData[dayData.date];
+    const updatedDaysData = { ...previousDaysData, [dayData.date]: dayData };
+
+    setDaysData(updatedDaysData);
+    saveDayData(dayData);
+    previousDaysDataRef.current = updatedDaysData;
 
     // Handle vacation/AP approval changes
     setConfig(prev => {
@@ -79,37 +78,29 @@ export function useTimeTracking() {
         const previousFlexUsed = previousDayData?.dayStatus === 'flexibilitat' ? (previousDayData?.flexHours || 0) : 0;
         const difference = dayData.flexHours - previousFlexUsed;
         if (difference !== 0) {
-          updatedConfig.flexibilityHours = Math.max(0, Math.min(25, updatedConfig.flexibilityHours - difference));
+          updatedConfig.flexibilityHours = Math.max(0, Math.min(MAX_FLEXIBILITY_HOURS, updatedConfig.flexibilityHours - difference));
         }
       }
       
       // If flex was used but now it's not flex, restore the hours
       if (previousDayData?.dayStatus === 'flexibilitat' && previousDayData?.flexHours) {
         if (dayData.dayStatus !== 'flexibilitat') {
-          updatedConfig.flexibilityHours = Math.min(25, updatedConfig.flexibilityHours + previousDayData.flexHours);
+          updatedConfig.flexibilityHours = Math.min(MAX_FLEXIBILITY_HOURS, updatedConfig.flexibilityHours + previousDayData.flexHours);
         }
       }
-      
-      // Check if worked 30+ min extra (only for laboral days)
-      if (dayData.dayStatus === 'laboral' && dayData.startTime && dayData.endTime) {
-        const date = new Date(dayData.date);
-        const worked = calculateWorkedHours(dayData.startTime, dayData.endTime);
-        const theoretical = getTheoreticalHoursForDate(date, updatedConfig);
-        const extra = worked - theoretical;
-        
-        // If extra >= 0.5h (30 min), add to flexibility (max 25h)
-        if (extra >= 0.5) {
-          const previousWorked = previousDayData?.startTime && previousDayData?.endTime 
-            ? calculateWorkedHours(previousDayData.startTime, previousDayData.endTime)
-            : 0;
-          const previousExtra = previousWorked - theoretical;
-          const previousFXAdded = previousExtra >= 0.5 ? previousExtra : 0;
-          const newFXToAdd = extra - previousFXAdded;
-          
-          if (newFXToAdd > 0) {
-            updatedConfig.flexibilityHours = Math.min(25, updatedConfig.flexibilityHours + newFXToAdd);
-          }
-        }
+
+      const weekStart = startOfWeek(new Date(dayData.date), { weekStartsOn: 1 });
+      const previousSummary = calculateWeeklySummary(weekStart, previousDaysData, prev);
+      const newSummary = calculateWeeklySummary(weekStart, updatedDaysData, prev);
+      const previousEligible = previousSummary.difference >= MIN_WEEKLY_SURPLUS_FOR_FLEXIBILITY ? previousSummary.difference : 0;
+      const newEligible = newSummary.difference >= MIN_WEEKLY_SURPLUS_FOR_FLEXIBILITY ? newSummary.difference : 0;
+      const weeklyDelta = newEligible - previousEligible;
+
+      if (weeklyDelta !== 0) {
+        updatedConfig.flexibilityHours = Math.min(
+          MAX_FLEXIBILITY_HOURS,
+          Math.max(0, updatedConfig.flexibilityHours + weeklyDelta)
+        );
       }
       
       if (JSON.stringify(updatedConfig) !== JSON.stringify(prev)) {


### PR DESCRIPTION
### Motivation
- Implement FX (flexibilitat) behavior based on weekly surplus: if weekly surplus >= 30 minutes it should contribute to the FX balance and changes to any day in the same week must update the FX total.
- Ensure the FX balance never exceeds the 25h maximum and that requesting FX deducts from the global balance.
- Prevent saving requests for more FX than available, including when editing an already-registered FX day.

### Description
- Updated `useTimeTracking` to compute FX accumulation per week by comparing `calculateWeeklySummary` before and after a day change and applying the delta to `config.flexibilityHours`, using `MAX_FLEXIBILITY_HOURS` and `MIN_WEEKLY_SURPLUS_FOR_FLEXIBILITY` to clamp behavior.
- Replaced the previous per-day extra handling with the new weekly delta logic and preserved restoration logic for removed FX/AP/vacances entries while keeping bounds checks.
- Modified `DayDetailDialog` to compute the available FX (including the previous FX value for the edited day) and cap the input and saved `flexHours` to the available balance and the day theoretical hours.
- Adjusted imports to use the new constants (`MAX_FLEXIBILITY_HOURS`, `MIN_WEEKLY_SURPLUS_FOR_FLEXIBILITY`) and minor cleanup in `useTimeTracking`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7a8354288327bb11be2018d3c7f6)