### PR TITLE
Track FX usage separately from accumulation and cap FX requests

### DIFF
--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -9,7 +9,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import type { DayData, UserConfig, DayStatus, RequestStatus } from '@/types';
 import { getTheoreticalHoursForDate, getDayTypeForDate, calculateWorkedHours, isHoliday, formatHoursToTime } from '@/lib/timeCalculations';
-import { DAY_NAMES_CA, MONTH_NAMES_CA } from '@/lib/constants';
+import { DAY_NAMES_CA, MAX_FLEXIBILITY_HOURS, MONTH_NAMES_CA } from '@/lib/constants';
 import { Home, Building2, Trash2 } from 'lucide-react';
 
 interface DayDetailDialogProps {
@@ -69,6 +69,12 @@ export function DayDetailDialog({ date, dayData, config, onClose, onSave }: DayD
   const dayType = getDayTypeForDate(date, config);
   const actualWorkedHours = startTime && endTime ? calculateWorkedHours(startTime, endTime) : 0;
   const absenceHoursDecimal = absenceHours + (absenceMinutes / 60);
+  const previousFlexHours = dayData?.dayStatus === 'flexibilitat' ? (dayData.flexHours || 0) : 0;
+  const availableFlexHours = Math.min(
+    MAX_FLEXIBILITY_HOURS,
+    Math.max(0, config.flexibilityHours - config.usedFlexHours + previousFlexHours)
+  );
+  const maxFlexHours = Math.min(theoreticalHours, availableFlexHours);
   
   // Total worked hours = actual worked + AP/FX hours (if applicable)
   const totalWorkedHours = absenceType === 'vacances' 
@@ -110,6 +116,9 @@ export function DayDetailDialog({ date, dayData, config, onClose, onSave }: DayD
   };
 
   const handleSave = () => {
+    const cappedFlexHours = absenceType === 'flexibilitat'
+      ? Math.min(getAbsenceHoursDecimal(), maxFlexHours)
+      : undefined;
     const newDayData: DayData = {
       date: format(date, 'yyyy-MM-dd'),
       theoreticalHours,
@@ -119,7 +128,7 @@ export function DayDetailDialog({ date, dayData, config, onClose, onSave }: DayD
       dayStatus: getDayStatus(),
       requestStatus: getRequestStatus(),
       apHours: absenceType === 'assumpte_propi' ? getAbsenceHoursDecimal() : undefined,
-      flexHours: absenceType === 'flexibilitat' ? getAbsenceHoursDecimal() : undefined,
+      flexHours: absenceType === 'flexibilitat' ? cappedFlexHours : undefined,
     };
     onSave(newDayData);
     onClose();
@@ -234,7 +243,7 @@ export function DayDetailDialog({ date, dayData, config, onClose, onSave }: DayD
                     id="absenceHours"
                     type="number"
                     min="0"
-                    max={Math.floor(theoreticalHours)}
+                    max={absenceType === 'flexibilitat' ? Math.floor(maxFlexHours) : Math.floor(theoreticalHours)}
                     value={absenceHours}
                     onChange={(e) => setAbsenceHours(parseInt(e.target.value) || 0)}
                   />

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,6 +41,7 @@ export const DEFAULT_USER_CONFIG = {
   totalAPHours: 90,
   usedAPHours: 0,
   flexibilityHours: 0,
+  usedFlexHours: 0,
   holidays: BARCELONA_HOLIDAYS_2026,
 };
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -23,6 +23,9 @@ export function getUserConfig(): UserConfig {
           friday: { dayType: parsed.weeklyConfig.friday?.dayType || 'teletreball' },
         };
       }
+      if (typeof parsed.usedFlexHours !== 'number') {
+        parsed.usedFlexHours = DEFAULT_USER_CONFIG.usedFlexHours;
+      }
       return parsed;
     }
   } catch (error) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -59,6 +59,7 @@ const UserConfigSchema = z.object({
   totalAPHours: z.number().min(0).max(500),
   usedAPHours: z.number().min(0).max(500),
   flexibilityHours: z.number().min(0).max(25),
+  usedFlexHours: z.number().min(0).max(25),
   holidays: z.array(z.string().regex(/^\d{4}-\d{2}-\d{2}$/)).max(100),
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -42,7 +42,8 @@ export interface UserConfig {
   usedVacationDays: number;
   totalAPHours: number;
   usedAPHours: number;
-  flexibilityHours: number; // Current accumulated (max 25)
+  flexibilityHours: number; // Accumulated (max 25)
+  usedFlexHours: number; // Used from accumulated
   holidays: string[]; // Array of YYYY-MM-DD
 }
 


### PR DESCRIPTION
### Motivation
- Ensure generated FX (acumulades) are not reduced when FX hours are spent, so users always see up to 25h generated separately from consumed hours. 
- Prevent requesting more FX than the net available balance (generated − used) when creating or editing FX days. 
- Migrate storage/validation to support tracking of consumed FX hours and keep existing weekly accumulation logic intact.

### Description
- Added `usedFlexHours` to `UserConfig` and default `DEFAULT_USER_CONFIG`, plus schema validation (`src/types/index.ts`, `src/lib/constants.ts`, `src/lib/validation.ts`).
- Added migration for older configs to initialize `usedFlexHours` in `getUserConfig` (`src/lib/storage.ts`).
- Updated `useTimeTracking` to track FX consumption by updating `usedFlexHours` when FX days are saved/removed and to keep weekly FX accumulation as `flexibilityHours` (clamped to `MAX_FLEXIBILITY_HOURS`), and to ensure `usedFlexHours <= flexibilityHours` (`src/hooks/useTimeTracking.ts`).
- Changed `DayDetailDialog` to compute available FX as `flexibilityHours - usedFlexHours` (+ previous day value when editing) and to cap requested `flexHours` to that available balance and the day theoretical hours (`src/components/Calendar/DayDetailDialog.tsx`).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e7a8354288327bb11be2018d3c7f6)