### PR TITLE
Remove FX (flexibility hours) edit option from Settings dialog

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -286,22 +286,6 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
               </div>
             </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="flexibility">Flexibilitat acumulada (hores)</Label>
-              <Input
-                id="flexibility"
-                type="number"
-                step="0.5"
-                max="25"
-                min="0"
-                value={localConfig.flexibilityHours}
-                onChange={(e) => setLocalConfig(prev => ({ 
-                  ...prev, 
-                  flexibilityHours: Math.min(25, Math.max(0, parseFloat(e.target.value) || 0))
-                }))}
-              />
-              <p className="text-xs text-muted-foreground">Màxim 25 hores</p>
-            </div>
           </TabsContent>
 
           <TabsContent value="schedule" className="space-y-4 pt-4">


### PR DESCRIPTION
### Motivation
- Remove the user-editable FX (flexibility hours) field from the settings dialog so accumulated flexibility cannot be edited from the UI.

### Description
- Deleted the "Flexibilitat acumulada (hores)" input and its label/description from `src/components/Settings/SettingsDialog.tsx`, removing the ability to update `flexibilityHours` via the settings UI.

### Testing
- Attempted to run `npm run dev` but `vite` was not found and `npm install` failed with a 403 from the npm registry, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e8000cd7c8327bd62add3abe7095d)