### PR TITLE
Reorganize weekly summary layout

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -143,59 +143,66 @@ export function WeeklySummaryDialog({
             return (
               <div
                 key={dateStr}
-                className={`p-4 rounded-lg space-y-4 border ${statusCardClass}`}
+                className={`p-4 rounded-lg border ${statusCardClass}`}
               >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-semibold">{getDayName(day)}, {format(day, 'd')}</span>
-                    <Badge variant={dayType === 'presencial' ? 'default' : 'secondary'} className="text-xs">
-                      <DayIcon className="w-3 h-3 mr-1" />
-                      {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
-                    </Badge>
-                    <Badge variant="outline" className="text-xs flex items-center gap-1">
-                      {StatusIcon && <StatusIcon className="w-3 h-3" />}
-                      {statusLabel}
-                    </Badge>
-                    {dayData?.requestStatus === 'aprovat' && (
-                      <Badge variant="outline" className="text-xs flex items-center gap-1">
-                        <Check className="w-3 h-3" />
-                        Aprovat
-                      </Badge>
-                    )}
-                    {excludedFromTotals && (
-                      <Badge variant="secondary" className="text-xs">
-                        No computa
-                      </Badge>
-                    )}
-                  </div>
-                  <Badge variant="outline">{formatHours(summaryTheoretical)} teòriques</Badge>
-                </div>
-                
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Horari</p>
-                    {holiday || dayData?.dayStatus === 'vacances' ? (
-                      <p className="font-medium">—</p>
-                    ) : dayData?.startTime && dayData?.endTime ? (
-                      <p className="font-medium">{dayData.startTime} - {dayData.endTime}</p>
-                    ) : (
-                      <p className="font-medium text-muted-foreground">Sense horari</p>
-                    )}
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Hores treballades</p>
-                    <p className="font-medium">{formatHours(summaryWorked)}</p>
-                    {extraHours > 0 && (
-                      <p className="text-xs text-muted-foreground">
-                        +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
+                <div className="grid grid-cols-1 md:grid-cols-[1.2fr_1fr] gap-4">
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Horari</p>
+                      {holiday || dayData?.dayStatus === 'vacances' ? (
+                        <p className="font-medium">—</p>
+                      ) : dayData?.startTime && dayData?.endTime ? (
+                        <p className="font-medium">{dayData.startTime} - {dayData.endTime}</p>
+                      ) : (
+                        <p className="font-medium text-muted-foreground">Sense horari</p>
+                      )}
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Hores treballades</p>
+                      <p className="font-medium">{formatHours(summaryWorked)}</p>
+                      {extraHours > 0 && (
+                        <p className="text-xs text-muted-foreground">
+                          +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
+                        </p>
+                      )}
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Diferència</p>
+                      <p className={`font-semibold ${dayDifference >= 0 ? 'text-[hsl(var(--status-complete))]' : 'text-[hsl(var(--status-deficit))]'}`}>
+                        {formatHoursDisplay(dayDifference)}
                       </p>
-                    )}
+                    </div>
                   </div>
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Diferència</p>
-                    <p className={`font-semibold ${dayDifference >= 0 ? 'text-[hsl(var(--status-complete))]' : 'text-[hsl(var(--status-deficit))]'}`}>
-                      {formatHoursDisplay(dayDifference)}
-                    </p>
+
+                  <div className="flex flex-col gap-2 md:items-end">
+                    <div className="text-sm text-muted-foreground">
+                      {getDayName(day)}
+                    </div>
+                    <div className="text-2xl font-semibold leading-none">
+                      {format(day, 'd')}
+                    </div>
+                    <Badge variant="outline">{formatHours(summaryTheoretical)}</Badge>
+                    <div className="flex flex-wrap gap-2 md:justify-end">
+                      <Badge variant={dayType === 'presencial' ? 'default' : 'secondary'} className="text-xs">
+                        <DayIcon className="w-3 h-3 mr-1" />
+                        {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
+                      </Badge>
+                      <Badge variant="outline" className="text-xs flex items-center gap-1">
+                        {StatusIcon && <StatusIcon className="w-3 h-3" />}
+                        {statusLabel}
+                      </Badge>
+                      {dayData?.requestStatus === 'aprovat' && (
+                        <Badge variant="outline" className="text-xs flex items-center gap-1">
+                          <Check className="w-3 h-3" />
+                          Aprovat
+                        </Badge>
+                      )}
+                      {excludedFromTotals && (
+                        <Badge variant="secondary" className="text-xs">
+                          No computa
+                        </Badge>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Make the weekly summary more readable on a single screen by surfacing the most relevant day metadata (day/date, theoretical hours and status badges) in a compact column while keeping schedule, worked hours and difference grouped together.

### Description
- Restructured the weekly day card in `src/components/Calendar/WeeklySummaryDialog.tsx` to a two-column layout using `md:grid-cols-[1.2fr_1fr]` and moved the day name, big date, theoretical hours and status badges to the right column. 
- Left column now groups `Horari`, `Hores treballades` and `Diferència` together in a compact grid to keep those items visible without horizontal scrolling. 
- Removed the trailing literal label `teòriques` from the daily theoretical hours badge so the badge only renders the formatted hours. 
- Adjusted container classes (removed the previous `space-y-4` grouping in each card and updated grid/flex classes) to match the new two-column presentation.

### Testing
- Attempted `npm install` to run the test/build pipeline, but the install failed with a `403 Forbidden` error when fetching `@testing-library/jest-dom`, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e81ece47c83279dd2dd9f722dd2d4)