### PR TITLE
Swap weekly summary columns and inline day metadata/badges

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -143,59 +143,63 @@ export function WeeklySummaryDialog({
             return (
               <div
                 key={dateStr}
-                className={`p-4 rounded-lg space-y-4 border ${statusCardClass}`}
+                className={`p-4 rounded-lg border ${statusCardClass}`}
               >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-semibold">{getDayName(day)}, {format(day, 'd')}</span>
-                    <Badge variant={dayType === 'presencial' ? 'default' : 'secondary'} className="text-xs">
-                      <DayIcon className="w-3 h-3 mr-1" />
-                      {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
-                    </Badge>
-                    <Badge variant="outline" className="text-xs flex items-center gap-1">
-                      {StatusIcon && <StatusIcon className="w-3 h-3" />}
-                      {statusLabel}
-                    </Badge>
-                    {dayData?.requestStatus === 'aprovat' && (
+                <div className="grid grid-cols-1 md:grid-cols-[1fr_1.2fr] gap-4">
+                  <div className="flex flex-col gap-2">
+                    <div className="text-lg font-semibold">
+                      {getDayName(day)}, {format(day, 'd')}
+                    </div>
+                    <Badge variant="outline">{formatHours(summaryTheoretical)}</Badge>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant={dayType === 'presencial' ? 'default' : 'secondary'} className="text-xs">
+                        <DayIcon className="w-3 h-3 mr-1" />
+                        {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
+                      </Badge>
                       <Badge variant="outline" className="text-xs flex items-center gap-1">
-                        <Check className="w-3 h-3" />
-                        Aprovat
+                        {StatusIcon && <StatusIcon className="w-3 h-3" />}
+                        {statusLabel}
                       </Badge>
-                    )}
-                    {excludedFromTotals && (
-                      <Badge variant="secondary" className="text-xs">
-                        No computa
-                      </Badge>
-                    )}
+                      {dayData?.requestStatus === 'aprovat' && (
+                        <Badge variant="outline" className="text-xs flex items-center gap-1">
+                          <Check className="w-3 h-3" />
+                          Aprovat
+                        </Badge>
+                      )}
+                      {excludedFromTotals && (
+                        <Badge variant="secondary" className="text-xs">
+                          No computa
+                        </Badge>
+                      )}
+                    </div>
                   </div>
-                  <Badge variant="outline">{formatHours(summaryTheoretical)} teòriques</Badge>
-                </div>
-                
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Horari</p>
-                    {holiday || dayData?.dayStatus === 'vacances' ? (
-                      <p className="font-medium">—</p>
-                    ) : dayData?.startTime && dayData?.endTime ? (
-                      <p className="font-medium">{dayData.startTime} - {dayData.endTime}</p>
-                    ) : (
-                      <p className="font-medium text-muted-foreground">Sense horari</p>
-                    )}
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Hores treballades</p>
-                    <p className="font-medium">{formatHours(summaryWorked)}</p>
-                    {extraHours > 0 && (
-                      <p className="text-xs text-muted-foreground">
-                        +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
+
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Horari</p>
+                      {holiday || dayData?.dayStatus === 'vacances' ? (
+                        <p className="font-medium">—</p>
+                      ) : dayData?.startTime && dayData?.endTime ? (
+                        <p className="font-medium">{dayData.startTime} - {dayData.endTime}</p>
+                      ) : (
+                        <p className="font-medium text-muted-foreground">Sense horari</p>
+                      )}
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Hores treballades</p>
+                      <p className="font-medium">{formatHours(summaryWorked)}</p>
+                      {extraHours > 0 && (
+                        <p className="text-xs text-muted-foreground">
+                          +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
+                        </p>
+                      )}
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Diferència</p>
+                      <p className={`font-semibold ${dayDifference >= 0 ? 'text-[hsl(var(--status-complete))]' : 'text-[hsl(var(--status-deficit))]'}`}>
+                        {formatHoursDisplay(dayDifference)}
                       </p>
-                    )}
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Diferència</p>
-                    <p className={`font-semibold ${dayDifference >= 0 ? 'text-[hsl(var(--status-complete))]' : 'text-[hsl(var(--status-deficit))]'}`}>
-                      {formatHoursDisplay(dayDifference)}
-                    </p>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Reverse the weekly summary columns so the day metadata appears on the left and the metrics on the right for a more compact, readable layout.
- Place the day name and day number on the same line and keep all status/type badges aligned on a single line to reduce vertical noise.
- Remove extra vertical spacing in the card container to better fit the two-column presentation.

### Description
- Updated `src/components/Calendar/WeeklySummaryDialog.tsx` to use `md:grid-cols-[1fr_1.2fr]` and moved day metadata (day name/date, theoretical hours badge and status/type badges) into the left column while moving `Horari`, `Hores treballades` and `Diferència` into the right metrics column.
- Combined the day name and number into one line with `getDayName(day), {format(day, 'd')}` and rendered the theoretical hours as a single `Badge` (`{formatHours(summaryTheoretical)}`) without the trailing literal label.
- Replaced the previous `space-y-4` card layout with a tighter grid/flex arrangement and adjusted badge containers to be inline (`flex flex-wrap gap-2`) for horizontal alignment.

### Testing
- No automated tests were run for this change.
- A previous attempt to run the install step failed when fetching `@testing-library/jest-dom` with a `403 Forbidden`, so the test/build pipeline was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e81ece47c83279dd2dd9f722dd2d4)