### PR TITLE
Inline theoretical-hours badge and compact daily summary layout

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -143,59 +143,63 @@ export function WeeklySummaryDialog({
             return (
               <div
                 key={dateStr}
-                className={`p-4 rounded-lg space-y-4 border ${statusCardClass}`}
+                className={`p-4 rounded-lg border ${statusCardClass}`}
               >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-2 flex-wrap">
-                    <span className="font-semibold">{getDayName(day)}, {format(day, 'd')}</span>
-                    <Badge variant={dayType === 'presencial' ? 'default' : 'secondary'} className="text-xs">
-                      <DayIcon className="w-3 h-3 mr-1" />
-                      {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
-                    </Badge>
-                    <Badge variant="outline" className="text-xs flex items-center gap-1">
-                      {StatusIcon && <StatusIcon className="w-3 h-3" />}
-                      {statusLabel}
-                    </Badge>
-                    {dayData?.requestStatus === 'aprovat' && (
+                <div className="grid grid-cols-1 md:grid-cols-[1fr_1.2fr] gap-4">
+                  <div className="flex flex-col gap-2">
+                    <div className="text-lg font-semibold">
+                      {getDayName(day)}, {format(day, 'd')}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Badge variant="outline">{formatHours(summaryTheoretical)}</Badge>
+                      <Badge variant={dayType === 'presencial' ? 'default' : 'secondary'} className="text-xs">
+                        <DayIcon className="w-3 h-3 mr-1" />
+                        {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
+                      </Badge>
                       <Badge variant="outline" className="text-xs flex items-center gap-1">
-                        <Check className="w-3 h-3" />
-                        Aprovat
+                        {StatusIcon && <StatusIcon className="w-3 h-3" />}
+                        {statusLabel}
                       </Badge>
-                    )}
-                    {excludedFromTotals && (
-                      <Badge variant="secondary" className="text-xs">
-                        No computa
-                      </Badge>
-                    )}
+                      {dayData?.requestStatus === 'aprovat' && (
+                        <Badge variant="outline" className="text-xs flex items-center gap-1">
+                          <Check className="w-3 h-3" />
+                          Aprovat
+                        </Badge>
+                      )}
+                      {excludedFromTotals && (
+                        <Badge variant="secondary" className="text-xs">
+                          No computa
+                        </Badge>
+                      )}
+                    </div>
                   </div>
-                  <Badge variant="outline">{formatHours(summaryTheoretical)} teòriques</Badge>
-                </div>
-                
-                <div className="grid grid-cols-1 md:grid-cols-3 gap-3 text-sm">
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Horari</p>
-                    {holiday || dayData?.dayStatus === 'vacances' ? (
-                      <p className="font-medium">—</p>
-                    ) : dayData?.startTime && dayData?.endTime ? (
-                      <p className="font-medium">{dayData.startTime} - {dayData.endTime}</p>
-                    ) : (
-                      <p className="font-medium text-muted-foreground">Sense horari</p>
-                    )}
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Hores treballades</p>
-                    <p className="font-medium">{formatHours(summaryWorked)}</p>
-                    {extraHours > 0 && (
-                      <p className="text-xs text-muted-foreground">
-                        +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
+
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Horari</p>
+                      {holiday || dayData?.dayStatus === 'vacances' ? (
+                        <p className="font-medium">—</p>
+                      ) : dayData?.startTime && dayData?.endTime ? (
+                        <p className="font-medium">{dayData.startTime} - {dayData.endTime}</p>
+                      ) : (
+                        <p className="font-medium text-muted-foreground">Sense horari</p>
+                      )}
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Hores treballades</p>
+                      <p className="font-medium">{formatHours(summaryWorked)}</p>
+                      {extraHours > 0 && (
+                        <p className="text-xs text-muted-foreground">
+                          +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
+                        </p>
+                      )}
+                    </div>
+                    <div className="space-y-1">
+                      <p className="text-muted-foreground">Diferència</p>
+                      <p className={`font-semibold ${dayDifference >= 0 ? 'text-[hsl(var(--status-complete))]' : 'text-[hsl(var(--status-deficit))]'}`}>
+                        {formatHoursDisplay(dayDifference)}
                       </p>
-                    )}
-                  </div>
-                  <div className="space-y-1">
-                    <p className="text-muted-foreground">Diferència</p>
-                    <p className={`font-semibold ${dayDifference >= 0 ? 'text-[hsl(var(--status-complete))]' : 'text-[hsl(var(--status-deficit))]'}`}>
-                      {formatHoursDisplay(dayDifference)}
-                    </p>
+                    </div>
                   </div>
                 </div>
               </div>


### PR DESCRIPTION
### Motivation
- Make daily summary cards more compact by placing the theoretical-hours badge on the same line as day metadata and status/type badges to reduce vertical noise.
- Improve readability by using a two-column card layout so metadata appears on the left and metrics on the right.

### Description
- Updated `src/components/Calendar/WeeklySummaryDialog.tsx` to remove the `space-y-4` vertical spacing and use a tighter grid with `md:grid-cols-[1fr_1.2fr]` for left metadata and right metrics.
- Moved the theoretical-hours badge into the day metadata line and grouped day type, status, approval and "No computa" badges inside a `flex flex-wrap gap-2` container for inline alignment.
- Replaced the previous single-row metrics with a `grid` of three columns (`sm:grid-cols-3`) on the right showing `Horari`, `Hores treballades`, and `Diferència` with existing logic preserved for holidays, extra hours and styling based on `dayDifference`.

### Testing
- No automated tests were run for this change.
- The project does not have `node_modules` installed in this environment, so the test/build pipeline could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e81ece47c83279dd2dd9f722dd2d4)