### PR TITLE
Update flex summary label

### DIFF
--- a/src/components/Summary/StatusSummary.tsx
+++ b/src/components/Summary/StatusSummary.tsx
@@ -72,7 +72,7 @@ export function StatusSummary({ config }: StatusSummaryProps) {
         <CardContent className="pt-0">
           <Progress value={flexProgress} className="h-2" />
           <p className="text-xs text-muted-foreground mt-1">
-            Màxim 25 hores acumulables
+            FX solicitades amb validació
           </p>
         </CardContent>
       </Card>


### PR DESCRIPTION
### Motivation
- Replace the static helper text under the Flexibilitat Horària card with the requested wording to indicate FX requests and validation status.

### Description
- Update the helper paragraph in `src/components/Summary/StatusSummary.tsx` to read "FX solicitades amb validació" instead of "Màxim 25 hores acumulables".

### Testing
- Ran `npm install` which failed with a 403 Forbidden from the npm registry, and `npm run dev` failed (`vite` not found) because dependencies could not be installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e86a7234c8327875c76fcbf6f2934)