### PR TITLE
Prevent requesting more vacation days than configured

### DIFF
--- a/src/components/Calendar/CalendarGrid.tsx
+++ b/src/components/Calendar/CalendarGrid.tsx
@@ -57,6 +57,7 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
   }
 
   const weekDayHeaders = ['Dl', 'Dt', 'Dc', 'Dj', 'Dv', 'Ds', 'Dg', ''];
+  const requestedVacationDays = Object.values(daysData).filter((day) => day.dayStatus === 'vacances').length;
 
   return (
     <div className="bg-card rounded-xl shadow-lg p-6">
@@ -139,6 +140,7 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
         date={selectedDate}
         dayData={selectedDate ? daysData[format(selectedDate, 'yyyy-MM-dd')] || null : null}
         config={config}
+        requestedVacationDays={requestedVacationDays}
         onClose={() => setSelectedDate(null)}
         onSave={onDayUpdate}
       />


### PR DESCRIPTION
### Motivation
- Enforce the configured total vacation days so users cannot request more vacation days than allowed across the calendar.
- Provide clear feedback in the day detail dialog when attempting to add a vacation beyond the limit.

### Description
- Count pending/requested vacation days in `CalendarGrid` and pass the total via `requestedVacationDays` into `DayDetailDialog`.
- Add `vacationError` state to `DayDetailDialog` and block saving a new vacation when `requestedVacationDays` would exceed `config.totalVacationDays` (with an exception for editing an already-vacation day by subtracting the current day from the count).
- Show a descriptive error message and clear it when switching away from the `vacances` selection or when the dialog data changes.
- Updated files: `src/components/Calendar/CalendarGrid.tsx` and `src/components/Calendar/DayDetailDialog.tsx`.

### Testing
- Ran `npm install` to prepare the project, which failed due to a registry permission error (`403 Forbidden` when fetching `@testing-library/jest-dom`), so the app could not be started and no integration or E2E runs were executed (failed).
- No unit tests or automated UI tests were run as the dependency install failed.
- Code changes were committed locally after modifications (`Prevent exceeding requested vacation days`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e8b582d088327ac7dc18265460e0e)