### PR TITLE
Prevent requesting more AP hours than available

### DIFF
--- a/src/components/Calendar/CalendarGrid.tsx
+++ b/src/components/Calendar/CalendarGrid.tsx
@@ -58,6 +58,12 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
 
   const weekDayHeaders = ['Dl', 'Dt', 'Dc', 'Dj', 'Dv', 'Ds', 'Dg', ''];
   const requestedVacationDays = Object.values(daysData).filter((day) => day.dayStatus === 'vacances').length;
+  const requestedAPHours = Object.values(daysData).reduce((total, day) => {
+    if (day.dayStatus !== 'assumpte_propi') {
+      return total;
+    }
+    return total + (day.apHours || 0);
+  }, 0);
 
   return (
     <div className="bg-card rounded-xl shadow-lg p-6">
@@ -141,6 +147,7 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
         dayData={selectedDate ? daysData[format(selectedDate, 'yyyy-MM-dd')] || null : null}
         config={config}
         requestedVacationDays={requestedVacationDays}
+        requestedAPHours={requestedAPHours}
         onClose={() => setSelectedDate(null)}
         onSave={onDayUpdate}
       />

--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -17,13 +17,14 @@ interface DayDetailDialogProps {
   dayData: DayData | null;
   config: UserConfig;
   requestedVacationDays: number;
+  requestedAPHours: number;
   onClose: () => void;
   onSave: (dayData: DayData) => void;
 }
 
 type AbsenceType = 'cap' | 'vacances' | 'assumpte_propi' | 'flexibilitat';
 
-export function DayDetailDialog({ date, dayData, config, requestedVacationDays, onClose, onSave }: DayDetailDialogProps) {
+export function DayDetailDialog({ date, dayData, config, requestedVacationDays, requestedAPHours, onClose, onSave }: DayDetailDialogProps) {
   const [startTime, setStartTime] = useState(config.defaultStartTime);
   const [endTime, setEndTime] = useState(config.defaultEndTime);
   const [absenceType, setAbsenceType] = useState<AbsenceType>('cap');
@@ -31,6 +32,7 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
   const [absenceHours, setAbsenceHours] = useState(0);
   const [absenceMinutes, setAbsenceMinutes] = useState(0);
   const [vacationError, setVacationError] = useState('');
+  const [apError, setApError] = useState('');
 
   useEffect(() => {
     if (dayData) {
@@ -64,6 +66,7 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
       setAbsenceMinutes(0);
     }
     setVacationError('');
+    setApError('');
   }, [dayData, config, date]);
 
   if (!date) return null;
@@ -72,12 +75,16 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
   const dayType = getDayTypeForDate(date, config);
   const actualWorkedHours = startTime && endTime ? calculateWorkedHours(startTime, endTime) : 0;
   const absenceHoursDecimal = absenceHours + (absenceMinutes / 60);
+  const previousAPHours = dayData?.dayStatus === 'assumpte_propi' ? (dayData.apHours || 0) : 0;
+  const effectiveRequestedAPHours = Math.max(0, requestedAPHours - previousAPHours);
+  const availableAPHours = Math.max(0, config.totalAPHours - effectiveRequestedAPHours);
   const previousFlexHours = dayData?.dayStatus === 'flexibilitat' ? (dayData.flexHours || 0) : 0;
   const availableFlexHours = Math.min(
     MAX_FLEXIBILITY_HOURS,
     Math.max(0, config.flexibilityHours - config.usedFlexHours + previousFlexHours)
   );
   const maxFlexHours = Math.min(theoreticalHours, availableFlexHours);
+  const exceedsAPLimit = absenceType === 'assumpte_propi' && absenceHoursDecimal > availableAPHours;
   
   // Total worked hours = actual worked + AP/FX hours (if applicable)
   const totalWorkedHours = absenceType === 'vacances' 
@@ -118,6 +125,14 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
     return absenceHours + (absenceMinutes / 60);
   };
 
+  useEffect(() => {
+    if (absenceType === 'assumpte_propi' && absenceHoursDecimal > availableAPHours) {
+      setApError("Ja has demanat el màxim d'hores d'AP.");
+    } else {
+      setApError('');
+    }
+  }, [absenceType, absenceHoursDecimal, availableAPHours]);
+
   const handleSave = () => {
     const isCurrentlyVacation = dayData?.dayStatus === 'vacances';
     const effectiveRequestedVacations = requestedVacationDays - (isCurrentlyVacation ? 1 : 0);
@@ -126,6 +141,11 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
 
     if (exceedsVacationLimit) {
       setVacationError('Ja has demanat el màxim de dies de vacances.');
+      return;
+    }
+
+    if (exceedsAPLimit) {
+      setApError("Ja has demanat el màxim d'hores d'AP.");
       return;
     }
 
@@ -235,6 +255,9 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
               } else {
                 setVacationError('');
               }
+              if (v !== 'assumpte_propi') {
+                setApError('');
+              }
               if (v === 'cap') {
                 setIsApproved(false);
                 setAbsenceHours(0);
@@ -254,6 +277,9 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
             {vacationError && (
               <p className="text-sm text-destructive">{vacationError}</p>
             )}
+            {apError && (
+              <p className="text-sm text-destructive">{apError}</p>
+            )}
           </div>
 
           {/* Hours/minutes input for AP or FX */}
@@ -266,7 +292,9 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
                     id="absenceHours"
                     type="number"
                     min="0"
-                    max={absenceType === 'flexibilitat' ? Math.floor(maxFlexHours) : Math.floor(theoreticalHours)}
+                    max={absenceType === 'flexibilitat'
+                      ? Math.floor(maxFlexHours)
+                      : Math.floor(Math.min(theoreticalHours, availableAPHours))}
                     value={absenceHours}
                     onChange={(e) => setAbsenceHours(parseInt(e.target.value) || 0)}
                   />


### PR DESCRIPTION
### Motivation
- Ensure AP (assumpte propi) requests cannot exceed the remaining available AP hours, similar to the existing vacation limits.

### Description
- Calculate total requested AP hours in `CalendarGrid` and pass the value to `DayDetailDialog` via a new `requestedAPHours` prop.
- In `DayDetailDialog` add `apError` state and compute `availableAPHours` from `config.totalAPHours`, subtracting already requested AP hours while accounting for the current day's previous AP value.
- Validate AP input on change and on save, show an error message when the request would exceed availability, and prevent saving in that case.
- Cap the hours input max to `Math.min(theoreticalHours, availableAPHours)` for AP entries and clear errors when switching away from AP.

### Testing
- No automated tests were executed as part of this change (none requested). 
- Attempted to run the dev server with `npm run dev`, but `vite` was not available in the environment so the server did not start. 
- `npm install` also failed due to a registry `403` preventing dependency installation, so runtime/manual verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696e905682b0832786cc7be5dfd732f3)