### PR TITLE
Validate and track AP hours when saving a day

### DIFF
--- a/src/hooks/useTimeTracking.ts
+++ b/src/hooks/useTimeTracking.ts
@@ -60,23 +60,16 @@ export function useTimeTracking() {
         }
       }
       
-      // Check if AP status changed to approved
-      if (dayData.dayStatus === 'assumpte_propi' && dayData.requestStatus === 'aprovat') {
-        const wasAPApproved = previousDayData?.dayStatus === 'assumpte_propi' && previousDayData?.requestStatus === 'aprovat';
-        const previousAPHours = wasAPApproved ? (previousDayData?.apHours || 0) : 0;
-        const newAPHours = dayData.apHours || 0;
-        const difference = newAPHours - previousAPHours;
-        if (difference !== 0) {
-          updatedConfig.usedAPHours = Math.max(0, Math.min(updatedConfig.totalAPHours, updatedConfig.usedAPHours + difference));
-        }
-      }
-      
-      // If AP was approved but now it's not AP or not approved, restore the hours
-      if (previousDayData?.dayStatus === 'assumpte_propi' && previousDayData?.requestStatus === 'aprovat') {
-        if (dayData.dayStatus !== 'assumpte_propi' || dayData.requestStatus !== 'aprovat') {
-          const previousAPHours = previousDayData?.apHours || 0;
-          updatedConfig.usedAPHours = Math.max(0, updatedConfig.usedAPHours - previousAPHours);
-        }
+      // Track AP hours usage regardless of approval
+      const previousAPHours = previousDayData?.dayStatus === 'assumpte_propi'
+        ? (previousDayData?.apHours || 0)
+        : 0;
+      const newAPHours = dayData.dayStatus === 'assumpte_propi'
+        ? (dayData.apHours || 0)
+        : 0;
+      const difference = newAPHours - previousAPHours;
+      if (difference !== 0) {
+        updatedConfig.usedAPHours = Math.max(0, Math.min(updatedConfig.totalAPHours, updatedConfig.usedAPHours + difference));
       }
       
       // Check if flexibility was used


### PR DESCRIPTION
### Motivation
- Prevent creating or updating a day that would consume more AP hours than available in the user config. 
- Keep the AP hours pool accurate when day entries change, independent of approval status. 
- Surface a clear error in the day dialog when the requested AP hours exceed the remaining balance.

### Description
- Updated `src/hooks/useTimeTracking.ts` to track AP hours deltas for `assumpte_propi` days regardless of `requestStatus`, adjusting `usedAPHours` by the difference between previous and new AP hours. 
- Added AP validation to `src/components/Calendar/DayDetailDialog.tsx` by introducing an `apError` state and calculating `availableAPHours` as `config.totalAPHours - config.usedAPHours + previousAPHours`. 
- Prevent saving when requested AP hours exceed `availableAPHours` and display the message `No queden prou hores d’AP disponibles.` in the dialog. 
- Clear the AP error when the absence type or AP hour inputs change so the message updates responsively.

### Testing
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which failed with `vite: not found`, so no automated runtime tests were executed. 
- No unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea4ac25b08327884c6fc4dee3bdcf)