### PR TITLE
Update default weekly configuration: Wednesday presencial, Thursday teletreball

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -24,8 +24,8 @@ export const DEFAULT_USER_CONFIG = {
   weeklyConfig: {
     monday: { dayType: 'presencial' as const },
     tuesday: { dayType: 'presencial' as const },
-    wednesday: { dayType: 'teletreball' as const },
-    thursday: { dayType: 'presencial' as const },
+    wednesday: { dayType: 'presencial' as const },
+    thursday: { dayType: 'teletreball' as const },
     friday: { dayType: 'teletreball' as const },
   },
   schedulePeriods: [

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -18,8 +18,8 @@ export function getUserConfig(): UserConfig {
         parsed.weeklyConfig = {
           monday: { dayType: parsed.weeklyConfig.monday?.dayType || 'presencial' },
           tuesday: { dayType: parsed.weeklyConfig.tuesday?.dayType || 'presencial' },
-          wednesday: { dayType: parsed.weeklyConfig.wednesday?.dayType || 'teletreball' },
-          thursday: { dayType: parsed.weeklyConfig.thursday?.dayType || 'presencial' },
+          wednesday: { dayType: parsed.weeklyConfig.wednesday?.dayType || 'presencial' },
+          thursday: { dayType: parsed.weeklyConfig.thursday?.dayType || 'teletreball' },
           friday: { dayType: parsed.weeklyConfig.friday?.dayType || 'teletreball' },
         };
       }


### PR DESCRIPTION
### Motivation
- Align the app defaults with the expected weekly schedule so defaults are Monday/Tuesday/Wednesday as `presencial` and Thursday/Friday as `teletreball`.
- Ensure migration from older saved configs uses the same updated defaults to avoid inconsistent behavior after upgrades.

### Description
- Change `DEFAULT_USER_CONFIG.weeklyConfig` in `src/lib/constants.ts` to set Wednesday to `presencial` and Thursday to `teletreball`.
- Update the legacy migration in `src/lib/storage.ts` to use the same defaults when normalizing old `weeklyConfig` shapes.
- Only the two files `src/lib/constants.ts` and `src/lib/storage.ts` were modified.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea4ed11f48327b337ca6038031680)