### PR TITLE
Make settings button icon-only with accessible aria-label

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -28,9 +28,13 @@ export function Header({ config, onOpenSettings }: HeaderProps) {
             </div>
           </div>
           
-          <Button variant="outline" onClick={onOpenSettings} className="gap-2">
+          <Button
+            variant="outline"
+            size="icon"
+            onClick={onOpenSettings}
+            aria-label="Configuració"
+          >
             <Settings className="w-4 h-4" />
-            Configuració
           </Button>
         </div>
       </div>


### PR DESCRIPTION
### Motivation
- The settings control should be visually simplified by removing the visible "Configuració" text and relying on the icon while keeping accessibility via a label.

### Description
- Replace the text-labeled settings button in `src/components/Header.tsx` with an icon-only `Button` using `size="icon"` and `aria-label="Configuració"` so the icon remains clickable and accessible.

### Testing
- Attempted to run `npm install` and `npm run dev`, but `npm install` failed with a `403 Forbidden` from the registry so the dev server could not be started and no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea53412ec8327a8afbb551d53a6c6)