### PR TITLE
Update header title and compact summary cards

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,9 +21,9 @@ export function Header({ config, onOpenSettings }: HeaderProps) {
               <Clock className="w-6 h-6 text-primary-foreground" />
             </div>
             <div>
-              <h1 className="text-xl font-bold text-foreground">Control Horari Educació</h1>
+              <h1 className="text-xl font-bold text-foreground">Control horari</h1>
               <p className="text-sm text-muted-foreground">
-                {userName} · Any 2026
+                {userName} · 2026
               </p>
             </div>
           </div>

--- a/src/components/Summary/StatusSummary.tsx
+++ b/src/components/Summary/StatusSummary.tsx
@@ -15,7 +15,7 @@ export function StatusSummary({ config }: StatusSummaryProps) {
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       <Card>
-        <CardHeader className="pb-2">
+        <CardHeader className="pb-2 space-y-1">
           <div className="flex items-center justify-between gap-4">
             <CardTitle className="text-sm font-medium flex items-center gap-2">
               <Plane className="w-4 h-4 text-[hsl(var(--status-vacation))]" />
@@ -23,20 +23,20 @@ export function StatusSummary({ config }: StatusSummaryProps) {
             </CardTitle>
             <div className="text-base font-semibold">
               {config.totalVacationDays - config.usedVacationDays}
-              <span className="text-sm font-normal text-muted-foreground"> dies disponibles</span>
+              <span className="text-sm font-normal text-muted-foreground"> dies</span>
             </div>
           </div>
+          <p className="text-xs text-muted-foreground">
+            {config.usedVacationDays} de {config.totalVacationDays} dies utilitzats
+          </p>
         </CardHeader>
         <CardContent className="pt-0">
           <Progress value={vacationProgress} className="h-2" />
-          <p className="text-xs text-muted-foreground mt-1">
-            {config.usedVacationDays} de {config.totalVacationDays} dies utilitzats
-          </p>
         </CardContent>
       </Card>
 
       <Card>
-        <CardHeader className="pb-2">
+        <CardHeader className="pb-2 space-y-1">
           <div className="flex items-center justify-between gap-4">
             <CardTitle className="text-sm font-medium flex items-center gap-2">
               <Clock className="w-4 h-4 text-primary" />
@@ -44,20 +44,20 @@ export function StatusSummary({ config }: StatusSummaryProps) {
             </CardTitle>
             <div className="text-base font-semibold">
               {(config.totalAPHours - config.usedAPHours).toFixed(1)}
-              <span className="text-sm font-normal text-muted-foreground"> hores disponibles</span>
+              <span className="text-sm font-normal text-muted-foreground"> hores</span>
             </div>
           </div>
+          <p className="text-xs text-muted-foreground">
+            {config.usedAPHours.toFixed(1)} de {config.totalAPHours} hores utilitzades
+          </p>
         </CardHeader>
         <CardContent className="pt-0">
           <Progress value={apProgress} className="h-2" />
-          <p className="text-xs text-muted-foreground mt-1">
-            {config.usedAPHours.toFixed(1)} de {config.totalAPHours} hores utilitzades
-          </p>
         </CardContent>
       </Card>
 
       <Card>
-        <CardHeader className="pb-2">
+        <CardHeader className="pb-2 space-y-1">
           <div className="flex items-center justify-between gap-4">
             <CardTitle className="text-sm font-medium flex items-center gap-2">
               <Sparkles className="w-4 h-4 text-[hsl(var(--status-complete))]" />
@@ -65,15 +65,15 @@ export function StatusSummary({ config }: StatusSummaryProps) {
             </CardTitle>
             <div className="text-base font-semibold">
               {config.flexibilityHours.toFixed(1)}
-              <span className="text-sm font-normal text-muted-foreground"> hores acumulades</span>
+              <span className="text-sm font-normal text-muted-foreground"> hores</span>
             </div>
           </div>
+          <p className="text-xs text-muted-foreground">
+            FX solicitades amb validació
+          </p>
         </CardHeader>
         <CardContent className="pt-0">
           <Progress value={flexProgress} className="h-2" />
-          <p className="text-xs text-muted-foreground mt-1">
-            FX solicitades amb validació
-          </p>
         </CardContent>
       </Card>
     </div>


### PR DESCRIPTION
### Motivation
- Simplificar el títol de l’aplicació a `Control horari` i treure la paraula `Any` per ajustar-se a la sol·licitud de disseny. 
- Fer les targetes de resum (Vacances, AP, FX) més compactes movent el text d’ús a la línia superior i escurçant les etiquetes per estalviar espai.

### Description
- Actualitzat `src/components/Header.tsx` per canviar el títol a `Control horari` i reemplaçar `Any 2026` per `2026` en la línia inferior amb el nom d’usuari. 
- Modificat `src/components/Summary/StatusSummary.tsx` per afegir `space-y-1` als `CardHeader` i moure els texts d’ús a la capçalera perquè apareguin a la línia superior. 
- Escurçat els sufixos a les targetes reemplaçant `dies disponibles`/`hores disponibles`/`hores acumulades` per `dies`/`hores` i mantenir la informació d’ús en una línia superior més petita. 
- Reorganitzat el markup perquè els paràgrafs de detall s’aboquin a la capçalera i s’eliminin duplicats en el contingut de la targeta.

### Testing
- Executat `npm install`, que ha fallat amb error (403 Forbidden) i ha impedit instal·lar dependències. 
- Executat `npm run dev -- --host 0.0.0.0 --port 4173`, que ha fallat perquè `vite` no està instal·lat a causa de la fallada anterior. 
- Cap suite de tests automatitzada addicional s’ha pogut executar a causa de l’error d’instal·lació de dependències.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea769582483279256cce596ddfcc2)