### PR TITLE
Move summary badges into header (compact StatusSummary)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button';
-import { Settings, Calendar, Clock } from 'lucide-react';
+import { StatusSummary } from '@/components/Summary/StatusSummary';
+import { Settings, Clock } from 'lucide-react';
 import type { UserConfig } from '@/types';
 
 interface HeaderProps {
@@ -15,19 +16,22 @@ export function Header({ config, onOpenSettings }: HeaderProps) {
   return (
     <header className="bg-card border-b border-border sticky top-0 z-50">
       <div className="container mx-auto px-4 py-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-primary rounded-lg">
-              <Clock className="w-6 h-6 text-primary-foreground" />
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:gap-6">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-primary rounded-lg">
+                <Clock className="w-6 h-6 text-primary-foreground" />
+              </div>
+              <div>
+                <h1 className="text-xl font-bold text-foreground">Control horari</h1>
+                <p className="text-sm text-muted-foreground">
+                  {userName} · 2026
+                </p>
+              </div>
             </div>
-            <div>
-              <h1 className="text-xl font-bold text-foreground">Control horari</h1>
-              <p className="text-sm text-muted-foreground">
-                {userName} · 2026
-              </p>
-            </div>
+            <StatusSummary config={config} variant="compact" />
           </div>
-          
+
           <Button
             variant="outline"
             size="icon"

--- a/src/components/Summary/StatusSummary.tsx
+++ b/src/components/Summary/StatusSummary.tsx
@@ -1,81 +1,100 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Progress } from '@/components/ui/progress';
-import { Plane, Clock, Sparkles, Calendar } from 'lucide-react';
+import { Plane, Clock, Sparkles } from 'lucide-react';
 import type { UserConfig } from '@/types';
 
 interface StatusSummaryProps {
   config: UserConfig;
+  variant?: 'default' | 'compact';
 }
 
-export function StatusSummary({ config }: StatusSummaryProps) {
+export function StatusSummary({ config, variant = 'default' }: StatusSummaryProps) {
   const vacationProgress = (config.usedVacationDays / config.totalVacationDays) * 100;
   const apProgress = (config.usedAPHours / config.totalAPHours) * 100;
   const flexProgress = (config.flexibilityHours / 25) * 100;
+  const summaryItems = [
+    {
+      key: 'vacances',
+      label: 'Vacances',
+      icon: Plane,
+      iconClassName: 'text-[hsl(var(--status-vacation))]',
+      value: (config.totalVacationDays - config.usedVacationDays).toString(),
+      unit: 'dies',
+      detail: `${config.usedVacationDays} de ${config.totalVacationDays} dies utilitzats`,
+      progress: vacationProgress,
+    },
+    {
+      key: 'ap',
+      label: 'Assumptes Propis',
+      icon: Clock,
+      iconClassName: 'text-primary',
+      value: (config.totalAPHours - config.usedAPHours).toFixed(1),
+      unit: 'hores',
+      detail: `${config.usedAPHours.toFixed(1)} de ${config.totalAPHours} hores utilitzades`,
+      progress: apProgress,
+    },
+    {
+      key: 'fx',
+      label: 'Flexibilitat Horària',
+      icon: Sparkles,
+      iconClassName: 'text-[hsl(var(--status-complete))]',
+      value: config.flexibilityHours.toFixed(1),
+      unit: 'hores',
+      detail: 'FX solicitades amb validació',
+      progress: flexProgress,
+    },
+  ];
+
+  if (variant === 'compact') {
+    return (
+      <div className="flex flex-wrap items-center gap-3">
+        {summaryItems.map((item) => {
+          const Icon = item.icon;
+          return (
+            <div
+              key={item.key}
+              className="flex items-center gap-3 rounded-lg border border-border bg-card/60 px-3 py-2 shadow-sm"
+            >
+              <div className="flex items-center gap-2">
+                <Icon className={`w-4 h-4 ${item.iconClassName}`} />
+                <span className="text-sm font-medium text-foreground">{item.label}</span>
+              </div>
+              <div className="text-sm font-semibold text-foreground">
+                {item.value}
+                <span className="text-xs font-normal text-muted-foreground"> {item.unit}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-      <Card>
-        <CardHeader className="pb-2 space-y-1">
-          <div className="flex items-center justify-between gap-4">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <Plane className="w-4 h-4 text-[hsl(var(--status-vacation))]" />
-              Vacances
-            </CardTitle>
-            <div className="text-base font-semibold">
-              {config.totalVacationDays - config.usedVacationDays}
-              <span className="text-sm font-normal text-muted-foreground"> dies</span>
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {config.usedVacationDays} de {config.totalVacationDays} dies utilitzats
-          </p>
-        </CardHeader>
-        <CardContent className="pt-0">
-          <Progress value={vacationProgress} className="h-2" />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2 space-y-1">
-          <div className="flex items-center justify-between gap-4">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <Clock className="w-4 h-4 text-primary" />
-              Assumptes Propis
-            </CardTitle>
-            <div className="text-base font-semibold">
-              {(config.totalAPHours - config.usedAPHours).toFixed(1)}
-              <span className="text-sm font-normal text-muted-foreground"> hores</span>
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {config.usedAPHours.toFixed(1)} de {config.totalAPHours} hores utilitzades
-          </p>
-        </CardHeader>
-        <CardContent className="pt-0">
-          <Progress value={apProgress} className="h-2" />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2 space-y-1">
-          <div className="flex items-center justify-between gap-4">
-            <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <Sparkles className="w-4 h-4 text-[hsl(var(--status-complete))]" />
-              Flexibilitat Horària
-            </CardTitle>
-            <div className="text-base font-semibold">
-              {config.flexibilityHours.toFixed(1)}
-              <span className="text-sm font-normal text-muted-foreground"> hores</span>
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            FX solicitades amb validació
-          </p>
-        </CardHeader>
-        <CardContent className="pt-0">
-          <Progress value={flexProgress} className="h-2" />
-        </CardContent>
-      </Card>
+      {summaryItems.map((item) => {
+        const Icon = item.icon;
+        return (
+          <Card key={item.key}>
+            <CardHeader className="pb-2 space-y-1">
+              <div className="flex items-center justify-between gap-4">
+                <CardTitle className="text-sm font-medium flex items-center gap-2">
+                  <Icon className={`w-4 h-4 ${item.iconClassName}`} />
+                  {item.label}
+                </CardTitle>
+                <div className="text-base font-semibold">
+                  {item.value}
+                  <span className="text-sm font-normal text-muted-foreground"> {item.unit}</span>
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">{item.detail}</p>
+            </CardHeader>
+            <CardContent className="pt-0">
+              <Progress value={item.progress} className="h-2" />
+            </CardContent>
+          </Card>
+        );
+      })}
     </div>
   );
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { Header } from '@/components/Header';
 import { CalendarGrid } from '@/components/Calendar/CalendarGrid';
-import { StatusSummary } from '@/components/Summary/StatusSummary';
 import { Legend } from '@/components/Legend';
 import { SettingsDialog } from '@/components/Settings/SettingsDialog';
 import { useTimeTracking } from '@/hooks/useTimeTracking';
@@ -15,12 +14,7 @@ const Index = () => {
     return (
       <div className="min-h-screen bg-background">
         <div className="container mx-auto px-4 py-6 space-y-6">
-          <Skeleton className="h-16 w-full" />
-          <div className="grid grid-cols-3 gap-4">
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-            <Skeleton className="h-32" />
-          </div>
+          <Skeleton className="h-20 w-full" />
           <Skeleton className="h-[500px]" />
         </div>
       </div>
@@ -32,8 +26,6 @@ const Index = () => {
       <Header config={config} onOpenSettings={() => setSettingsOpen(true)} />
       
       <main className="container mx-auto px-4 py-6 space-y-6">
-        <StatusSummary config={config} />
-        
         <CalendarGrid
           daysData={daysData}
           config={config}


### PR DESCRIPTION
### Motivation
- The Vacances, Assumptes Propis (AP) and Flexibilitat Horària (FX) metrics should appear horizontally next to the “Control horari” title in the header for a more compact, at-a-glance layout.
- Reduce duplicated markup in the status summary by consolidating items into a data-driven list for easier maintenance.

### Description
- Added a `variant?: 'default' | 'compact'` prop to `StatusSummary` and implemented a compact inline layout used by the header by defaulting `variant` to `'default'` and rendering `'compact'` in the header via `StatusSummary config={config} variant="compact"` (changed `src/components/Summary/StatusSummary.tsx` and `src/components/Header.tsx`).
- Replaced the previous three-card layout with a `summaryItems` array and map-based rendering to avoid duplicated JSX and to provide a compact badge layout for header use (`src/components/Summary/StatusSummary.tsx`).
- Moved the standalone summary out of the main page and render the compact summary inside the header, removing the `StatusSummary` block from `src/pages/Index.tsx` and adjusting loading skeleton sizes accordingly.
- Minor cleanup of unused imports in `StatusSummary` and layout adjustments in `Header` to accommodate the inline badges (`src/components/Header.tsx`, `src/pages/Index.tsx`).

### Testing
- Attempted to run the dev server with `npm run dev`, but `vite` was not found so the server did not start.
- Attempted `npm install`, but dependency installation failed with a registry `403` error which prevented running the app or automated tests.
- No automated tests were executed due to the blocked dependency install.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea8e66be08327b95f7f7474e45812)