### PR TITLE
Drop default end time and compute day end from start + schedule hours

### DIFF
--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import type { DayData, UserConfig, DayStatus, RequestStatus } from '@/types';
-import { getTheoreticalHoursForDate, getDayTypeForDate, calculateWorkedHours, isHoliday, formatHoursToTime } from '@/lib/timeCalculations';
+import { getTheoreticalHoursForDate, getDayTypeForDate, calculateWorkedHours, isHoliday, formatHoursToTime, parseTimeToHours } from '@/lib/timeCalculations';
 import { DAY_NAMES_CA, MAX_FLEXIBILITY_HOURS, MONTH_NAMES_CA } from '@/lib/constants';
 import { Home, Building2, Trash2 } from 'lucide-react';
 
@@ -25,7 +25,6 @@ type AbsenceType = 'cap' | 'vacances' | 'assumpte_propi' | 'flexibilitat';
 
 export function DayDetailDialog({ date, dayData, config, requestedVacationDays, onClose, onSave }: DayDetailDialogProps) {
   const [startTime, setStartTime] = useState(config.defaultStartTime);
-  const [endTime, setEndTime] = useState(config.defaultEndTime);
   const [absenceType, setAbsenceType] = useState<AbsenceType>('cap');
   const [isApproved, setIsApproved] = useState(false);
   const [absenceHours, setAbsenceHours] = useState(0);
@@ -36,7 +35,6 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
   useEffect(() => {
     if (dayData) {
       setStartTime(dayData.startTime === null ? '' : (dayData.startTime ?? config.defaultStartTime));
-      setEndTime(dayData.endTime === null ? '' : (dayData.endTime ?? config.defaultEndTime));
       
       // Determine absence type from dayStatus
       if (dayData.dayStatus === 'vacances') {
@@ -58,7 +56,6 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
       setIsApproved(dayData.requestStatus === 'aprovat');
     } else {
       setStartTime(config.defaultStartTime);
-      setEndTime(config.defaultEndTime);
       setAbsenceType('cap');
       setIsApproved(false);
       setAbsenceHours(0);
@@ -72,7 +69,12 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
 
   const theoreticalHours = getTheoreticalHoursForDate(date, config);
   const dayType = getDayTypeForDate(date, config);
-  const actualWorkedHours = startTime && endTime ? calculateWorkedHours(startTime, endTime) : 0;
+  const calculatedEndTime = startTime
+    ? formatHoursToTime(parseTimeToHours(startTime) + theoreticalHours)
+    : '';
+  const actualWorkedHours = startTime && calculatedEndTime
+    ? calculateWorkedHours(startTime, calculatedEndTime)
+    : 0;
   const absenceHoursDecimal = absenceHours + (absenceMinutes / 60);
   const previousFlexHours = dayData?.dayStatus === 'flexibilitat' ? (dayData.flexHours || 0) : 0;
   const previousAPHours = dayData?.dayStatus === 'assumpte_propi' ? (dayData.apHours || 0) : 0;
@@ -145,7 +147,7 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
       date: format(date, 'yyyy-MM-dd'),
       theoreticalHours,
       startTime: absenceType === 'vacances' ? null : (startTime || null),
-      endTime: absenceType === 'vacances' ? null : (endTime || null),
+      endTime: absenceType === 'vacances' ? null : (startTime ? calculatedEndTime : null),
       dayType,
       dayStatus: getDayStatus(),
       requestStatus: getRequestStatus(),
@@ -179,9 +181,9 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
             {holiday && <Badge variant="destructive">Festiu</Badge>}
           </div>
 
-          {/* Start and end time */}
-          {absenceType !== 'vacances' && startTime && endTime && (
-            <div className="grid grid-cols-[1fr_1fr_auto] gap-4 items-end">
+          {/* Start time */}
+          {absenceType !== 'vacances' && startTime && (
+            <div className="grid grid-cols-[1fr_auto] gap-4 items-end">
               <div className="space-y-2">
                 <Label htmlFor="startTime">Hora d'inici</Label>
                 <Input
@@ -192,22 +194,12 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
                   min="07:30"
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="endTime">Hora de fi</Label>
-                <Input
-                  id="endTime"
-                  type="time"
-                  value={endTime}
-                  onChange={(e) => setEndTime(e.target.value)}
-                />
-              </div>
               <Button
                 type="button"
                 variant="ghost"
                 size="icon"
                 onClick={() => {
                   setStartTime('');
-                  setEndTime('');
                 }}
                 className="text-muted-foreground hover:text-destructive"
                 title="Esborrar horari"
@@ -217,14 +209,19 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
             </div>
           )}
 
+          {absenceType !== 'vacances' && startTime && (
+            <p className="text-sm text-muted-foreground">
+              Hora de fi calculada: <span className="font-medium text-foreground">{calculatedEndTime}</span>
+            </p>
+          )}
+
           {/* Show add time button when no times */}
-          {absenceType !== 'vacances' && (!startTime || !endTime) && (
+          {absenceType !== 'vacances' && !startTime && (
             <Button
               type="button"
               variant="outline"
               onClick={() => {
                 setStartTime(config.defaultStartTime);
-                setEndTime(config.defaultEndTime);
               }}
               className="w-full"
             >

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -289,7 +289,7 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
           </TabsContent>
 
           <TabsContent value="schedule" className="space-y-4 pt-4">
-            <div className="grid grid-cols-2 gap-4 mb-6">
+            <div className="grid gap-4 mb-6">
               <div className="space-y-2">
                 <Label htmlFor="defaultStart">Hora d'inici per defecte</Label>
                 <Input
@@ -297,15 +297,6 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                   type="time"
                   value={localConfig.defaultStartTime}
                   onChange={(e) => setLocalConfig(prev => ({ ...prev, defaultStartTime: e.target.value }))}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="defaultEnd">Hora de fi per defecte</Label>
-                <Input
-                  id="defaultEnd"
-                  type="time"
-                  value={localConfig.defaultEndTime}
-                  onChange={(e) => setLocalConfig(prev => ({ ...prev, defaultEndTime: e.target.value }))}
                 />
               </div>
             </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -20,7 +20,6 @@ export const DEFAULT_USER_CONFIG = {
   firstName: '',
   lastName: '',
   defaultStartTime: '07:30',
-  defaultEndTime: '15:00',
   weeklyConfig: {
     monday: { dayType: 'presencial' as const },
     tuesday: { dayType: 'presencial' as const },

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -51,7 +51,6 @@ const UserConfigSchema = z.object({
   firstName: z.string().max(100).default(''),
   lastName: z.string().max(100).default(''),
   defaultStartTime: z.string().regex(/^\d{2}:\d{2}$/).default('08:00'),
-  defaultEndTime: z.string().regex(/^\d{2}:\d{2}$/).default('15:30'),
   weeklyConfig: WeeklyConfigSchema,
   schedulePeriods: z.array(SchedulePeriodSchema).max(100),
   totalVacationDays: z.number().min(0).max(365),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,7 +35,6 @@ export interface UserConfig {
   firstName: string;
   lastName: string;
   defaultStartTime: string;
-  defaultEndTime: string;
   weeklyConfig: WeeklyConfig;
   schedulePeriods: SchedulePeriod[];
   totalVacationDays: number;


### PR DESCRIPTION
### Motivation
- Simplify configuration to only require a default start time and remove the manual default end time to avoid redundant inputs.
- Ensure the displayed and saved end time is always consistent with the start time plus the theoretical hours for the active schedule (estiu/hivern).

### Description
- Removed `defaultEndTime` from the `UserConfig` type in `src/types/index.ts`, from `DEFAULT_USER_CONFIG` in `src/lib/constants.ts`, and from the schema in `src/lib/validation.ts`.
- Simplified the schedule settings UI in `src/components/Settings/SettingsDialog.tsx` to only collect `defaultStartTime` with the label `Hora d'inici per defecte`.
- Updated `src/components/Calendar/DayDetailDialog.tsx` to drop the editable end-time state and instead compute `endTime = startTime + theoreticalHours` using `parseTimeToHours` and `formatHoursToTime`, display the calculated end time, and save it with the day data.
- Kept all other logic (AP/FX handling, vacation requests, weekly configuration, schedule periods) intact while adapting usages that referenced the removed `defaultEndTime`.

### Testing
- Attempted to install dependencies with `npm install`, but the install failed due to a `403 Forbidden` error from the npm registry so the test environment could not be prepared.
- No automated test runner (`vitest`) was executed because the dependency installation failed, so no unit/integration tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ea95f292c8327a50b60927d002f6c)