### PR TITLE
Convert legend to popover and add missing status colors and icons

### DIFF
--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,43 +1,89 @@
-import { Home, Building2, Plane, Clock, Sparkles, Calendar } from 'lucide-react';
+import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check, Info } from 'lucide-react';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
 export function Legend() {
   return (
-    <div className="bg-card rounded-xl shadow-lg p-4">
-      <h3 className="text-sm font-semibold mb-3 text-foreground">Llegenda</h3>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-sm">
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 rounded bg-[hsl(var(--status-pending))]" />
-          <span className="text-muted-foreground">Pendent</span>
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm font-semibold text-foreground shadow-sm transition hover:bg-accent"
+        >
+          <Info className="h-4 w-4" />
+          Llegenda
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-4">
+        <h3 className="text-sm font-semibold mb-3 text-foreground">Llegenda</h3>
+        <div className="space-y-4 text-sm">
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Colors</p>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-[hsl(var(--status-weekday-empty))]" />
+                <span className="text-muted-foreground">Sense dades</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-[hsl(var(--status-pending))]" />
+                <span className="text-muted-foreground">Pendent</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-[hsl(var(--status-deficit))]" />
+                <span className="text-muted-foreground">Dèficit d'hores</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-[hsl(var(--status-complete))]" />
+                <span className="text-muted-foreground">Hores complertes</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-[hsl(var(--status-holiday))]" />
+                <span className="text-muted-foreground">Festiu</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-[hsl(var(--status-vacation))]" />
+                <span className="text-muted-foreground">Vacances</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <div className="w-4 h-4 rounded bg-[hsl(var(--status-weekend))]" />
+                <span className="text-muted-foreground">Cap de setmana</span>
+              </div>
+            </div>
+          </div>
+          <div>
+            <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground">Símbols</p>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="flex items-center gap-2">
+                <Building2 className="w-4 h-4 text-muted-foreground" />
+                <span className="text-muted-foreground">Presencial</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Home className="w-4 h-4 text-muted-foreground" />
+                <span className="text-muted-foreground">Teletreball</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Plane className="w-4 h-4 text-muted-foreground" />
+                <span className="text-muted-foreground">Vacances</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Clock className="w-4 h-4 text-muted-foreground" />
+                <span className="text-muted-foreground">Assumpte propi</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Sparkles className="w-4 h-4 text-muted-foreground" />
+                <span className="text-muted-foreground">Flexibilitat</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Calendar className="w-4 h-4 text-muted-foreground" />
+                <span className="text-muted-foreground">Festiu</span>
+              </div>
+              <div className="flex items-center gap-2">
+                <Check className="w-4 h-4 text-muted-foreground" />
+                <span className="text-muted-foreground">Aprovat</span>
+              </div>
+            </div>
+          </div>
         </div>
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 rounded bg-[hsl(var(--status-deficit))]" />
-          <span className="text-muted-foreground">Dèficit d'hores</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 rounded bg-[hsl(var(--status-complete))]" />
-          <span className="text-muted-foreground">Hores complertes</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 rounded bg-[hsl(var(--status-holiday))]" />
-          <span className="text-muted-foreground">Festiu</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 rounded bg-[hsl(var(--status-vacation))]" />
-          <span className="text-muted-foreground">Vacances</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <Building2 className="w-4 h-4 text-muted-foreground" />
-          <span className="text-muted-foreground">Presencial</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <Home className="w-4 h-4 text-muted-foreground" />
-          <span className="text-muted-foreground">Teletreball</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <div className="w-4 h-4 rounded bg-[hsl(var(--status-weekend))]" />
-          <span className="text-muted-foreground">Cap de setmana</span>
-        </div>
-      </div>
-    </div>
+      </PopoverContent>
+    </Popover>
   );
 }


### PR DESCRIPTION
### Motivation
- Turn the static legend into a popup to reduce visual clutter and ensure the legend includes all colors and symbols used by the calendar UI.

### Description
- Replace the original static `div` legend with a `Popover` trigger button and `PopoverContent` containing the legend layout.
- Add `Info` and `Check` icon imports from `lucide-react` and import `Popover` helpers from `@/components/ui/popover` to support the popup behavior.
- Add the missing `--status-weekday-empty` entry labeled `Sense dades` and include the approval (`Aprovat`) icon plus the full set of color and symbol mappings (vacances, assumpte propi, flexibilitat, festiu, presencial, teletreball, cap de setmana, etc.).

### Testing
- `npm install` was attempted but failed with a `403 Forbidden` error from the registry so dependencies were not installed.
- `npm run dev` was attempted but failed because `vite` was not available due to the failed install.
- No automated tests or dev server verification could be run as a result of the install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eaad86c1c83278125b2190ab0eaf3)