### PR TITLE
Auto-calculate day end time and simplify schedule defaults

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -289,25 +289,17 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
           </TabsContent>
 
           <TabsContent value="schedule" className="space-y-4 pt-4">
-            <div className="grid grid-cols-2 gap-4 mb-6">
-              <div className="space-y-2">
-                <Label htmlFor="defaultStart">Hora d'inici per defecte</Label>
-                <Input
-                  id="defaultStart"
-                  type="time"
-                  value={localConfig.defaultStartTime}
-                  onChange={(e) => setLocalConfig(prev => ({ ...prev, defaultStartTime: e.target.value }))}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="defaultEnd">Hora de fi per defecte</Label>
-                <Input
-                  id="defaultEnd"
-                  type="time"
-                  value={localConfig.defaultEndTime}
-                  onChange={(e) => setLocalConfig(prev => ({ ...prev, defaultEndTime: e.target.value }))}
-                />
-              </div>
+            <div className="mb-6 flex items-center gap-3">
+              <Label htmlFor="defaultStart" className="min-w-[200px]">
+                Hora d'inici per defecte
+              </Label>
+              <Input
+                id="defaultStart"
+                type="time"
+                value={localConfig.defaultStartTime}
+                onChange={(e) => setLocalConfig(prev => ({ ...prev, defaultStartTime: e.target.value }))}
+                className="max-w-[160px]"
+              />
             </div>
 
             <div className="space-y-3">


### PR DESCRIPTION
### Motivation
- Simplify schedule settings by removing the redundant default end time and align the default start-time input layout.
- Make per-day end times consistent by auto-calculating the end time from the start time plus the theoretical day length while preserving manual overrides.

### Description
- Removed the `defaultEndTime` input from the schedule tab and realigned the default start-time row in `src/components/Settings/SettingsDialog.tsx`.
- Added automatic end-time calculation logic to `src/components/Calendar/DayDetailDialog.tsx` using `parseTimeToHours` and `formatHoursToTime`, and introduced `isEndTimeAuto` to keep track of manual overrides.
- Updated `DayDetailDialog` behavior so that when a start time is set (or defaulted) the end time is set to `start + theoreticalHours` unless the user manually edits the end time, and preserved existing handling for explicit `null` end times.
- Adjusted imports and state handling in `DayDetailDialog` to support the new calculation and reset behaviors.

### Testing
- Attempted to start the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, but it failed because `vite` was not available in the environment (dev server not started).
- Attempted `npm install` to fetch dependencies, but it failed with a `403 Forbidden` error from the npm registry, so automated tests and local verification could not be run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ead0e8730832780764563e3535002)