### PR TITLE
Hide weekly summary until a day is saved

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -33,6 +33,8 @@ export function WeeklySummaryDialog({
   if (!weekStart || !weekEnd) return null;
 
   const days = eachDayOfInterval({ start: weekStart, end: weekEnd });
+  const hasAnyData = days.some((day) => !!daysData[format(day, 'yyyy-MM-dd')]);
+  if (!hasAnyData) return null;
   const weekNumber = getWeek(weekStart, { weekStartsOn: 1 });
 
   const getDayName = (date: Date) => {

--- a/src/components/Calendar/WeeklySummaryIcon.tsx
+++ b/src/components/Calendar/WeeklySummaryIcon.tsx
@@ -14,10 +14,14 @@ interface WeeklySummaryIconProps {
 
 export function WeeklySummaryIcon({ weekStart, weekEnd, daysData, config, onClick }: WeeklySummaryIconProps) {
   const days = eachDayOfInterval({ start: weekStart, end: weekEnd });
+  const hasAnyData = days.some((day) => !!daysData[format(day, 'yyyy-MM-dd')]);
+
+  if (!hasAnyData) {
+    return null;
+  }
   
   // Check if all workdays have data or are properly handled
   let allComplete = true;
-  let hasAnyData = false;
   let totalTheoretical = 0;
   let totalWorked = 0;
   
@@ -45,9 +49,7 @@ export function WeeklySummaryIcon({ weekStart, weekEnd, daysData, config, onClic
       allComplete = false;
       continue;
     }
-    
-    hasAnyData = true;
-    
+
     // Check if pending approval
     if (dayData.requestStatus === 'pendent') {
       allComplete = false;
@@ -59,11 +61,6 @@ export function WeeklySummaryIcon({ weekStart, weekEnd, daysData, config, onClic
     }
   }
   
-  // If no data at all, show yellow
-  if (!hasAnyData) {
-    allComplete = false;
-  }
-
   const difference = totalWorked - totalTheoretical;
   const hasNegativeDifference = difference < 0;
   


### PR DESCRIPTION
### Motivation
- The weekly summary UI should not be visible for weeks where no day has been saved so users don't see empty/incorrect summaries until they enter data.

### Description
- Added an early guard in `src/components/Calendar/WeeklySummaryIcon.tsx` that computes `hasAnyData` and returns `null` when a week has no saved day entries so the icon is hidden.
- Added the same `hasAnyData` guard to `src/components/Calendar/WeeklySummaryDialog.tsx` so the dialog does not render for weeks without saved day data.
- Kept existing completion and totals logic unchanged and removed the now-redundant `hasAnyData` flag usage inside the icon logic.

### Testing
- Attempted `npm install` which failed with a `403 Forbidden` from the registry so dependencies could not be installed.
- Attempted to start the dev server with `npm run dev` which failed because `vite` was not available after the install failure, so no integration/manual UI verification was run.
- No automated tests (`vitest`) were executed due to the dependency installation failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eaf4eb3188327a9966a177e74e026)