### PR TITLE
Inline weekly summary header date

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -109,12 +109,14 @@ export function WeeklySummaryDialog({
     <Dialog open={!!weekStart} onOpenChange={() => onClose()}>
       <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="text-xl">
-            Resum Setmana {weekNumber}
-          </DialogTitle>
-          <p className="text-sm text-muted-foreground">
-            {format(weekStart, 'd')} - {format(weekEnd, 'd')} de {MONTH_NAMES_CA[weekStart.getMonth()]}
-          </p>
+          <div className="flex flex-wrap items-baseline gap-2">
+            <DialogTitle className="text-xl">
+              Resum Setmana {weekNumber}
+            </DialogTitle>
+            <p className="text-sm text-muted-foreground">
+              {format(weekStart, 'd')} - {format(weekEnd, 'd')} de {MONTH_NAMES_CA[weekStart.getMonth()]}
+            </p>
+          </div>
         </DialogHeader>
 
         <div className="space-y-4 py-4">


### PR DESCRIPTION
### Motivation
- Reduce vertical space in the weekly summary dialog header by placing the week title and date on the same line.

### Description
- Wrap the `DialogTitle` and date paragraph in a `div` with `className="flex flex-wrap items-baseline gap-2"` in `src/components/Calendar/WeeklySummaryDialog.tsx` so the title and date render inline.

### Testing
- Attempted to run `npm run dev` and `npm install`; `npm run dev` failed because `vite` was not found and `npm install` failed with a `403` from the registry, so no further automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb0e5f4348327b7286d70c0628adc)