### PR TITLE
Refine weekly summary header typography

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -109,12 +109,14 @@ export function WeeklySummaryDialog({
     <Dialog open={!!weekStart} onOpenChange={() => onClose()}>
       <DialogContent className="sm:max-w-4xl max-h-[90vh] overflow-y-auto">
         <DialogHeader>
-          <DialogTitle className="text-xl">
-            Resum Setmana {weekNumber}
-          </DialogTitle>
-          <p className="text-sm text-muted-foreground">
-            {format(weekStart, 'd')} - {format(weekEnd, 'd')} de {MONTH_NAMES_CA[weekStart.getMonth()]}
-          </p>
+          <div className="flex flex-wrap items-baseline gap-3">
+            <DialogTitle className="text-2xl font-semibold tracking-tight text-foreground">
+              Resum Setmana {weekNumber}
+            </DialogTitle>
+            <p className="text-base font-medium text-muted-foreground">
+              {format(weekStart, 'd')} - {format(weekEnd, 'd')} de {MONTH_NAMES_CA[weekStart.getMonth()]}
+            </p>
+          </div>
         </DialogHeader>
 
         <div className="space-y-4 py-4">


### PR DESCRIPTION
### Motivation
- Improve the visual hierarchy and reduce vertical space in the weekly summary header so it looks more professional.
- Keep the week title and date inline while adjusting sizes and weights for better readability.

### Description
- Update `src/components/Calendar/WeeklySummaryDialog.tsx` to wrap the title and date in a `div` with `className="flex flex-wrap items-baseline gap-3"` to align them on one line.
- Increase the title size and weight by changing `DialogTitle` from `text-xl` to `text-2xl font-semibold tracking-tight text-foreground`.
- Strengthen the date styling by changing the `<p>` from `text-sm text-muted-foreground` to `text-base font-medium text-muted-foreground`.

### Testing
- Attempted to run `npm install` and `npm run dev` but `npm install` failed due to registry access and the dev server could not be started, so no automated tests were executed.
- No additional CI or unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb0e5f4348327b7286d70c0628adc)