### PR TITLE
Fix schedule period date independence in SettingsDialog

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -43,7 +43,8 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
       for (const period of periods) {
         const start = parseISO(period.startDate);
         const end = parseISO(period.endDate);
-        if (isWithinInterval(day, { start, end })) {
+        const [rangeStart, rangeEnd] = start > end ? [end, start] : [start, end];
+        if (isWithinInterval(day, { start: rangeStart, end: rangeEnd })) {
           coveredDays++;
           break;
         }
@@ -90,12 +91,6 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
         updatedPeriod.scheduleType = value as ScheduleType;
       } else {
         updatedPeriod[field] = value;
-        if (field === 'startDate' && updatedPeriod.startDate > updatedPeriod.endDate) {
-          updatedPeriod.endDate = updatedPeriod.startDate;
-        }
-        if (field === 'endDate' && updatedPeriod.endDate < updatedPeriod.startDate) {
-          updatedPeriod.startDate = updatedPeriod.endDate;
-        }
       }
 
       const updatedPeriods = [...prev.schedulePeriods];


### PR DESCRIPTION
### Motivation
- Prevent editing one date of a schedule period from automatically mutating the paired date so start and end are independent. 
- Ensure the coverage validation handles inverted ranges without altering stored period dates so the missing-days check remains robust.

### Description
- In `validateScheduleCoverage` normalize the interval bounds with `const [rangeStart, rangeEnd] = start > end ? [end, start] : [start, end]` and use those for `isWithinInterval`, so inverted dates are validated without changing stored values. 
- Removed the auto-adjust logic in `updateSchedulePeriod` that set the other date when `startDate` became greater than `endDate` (and vice versa), allowing each date field to be edited independently. 
- Kept existing sorting (`sortSchedulePeriods`) and save behavior so periods are still stored sorted and the UI warning about missing days continues to function.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb38252308327a7ffdc77ed082732)