### PR TITLE
Add support for split work shifts

### DIFF
--- a/src/components/Calendar/WeeklySummaryIcon.tsx
+++ b/src/components/Calendar/WeeklySummaryIcon.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/utils';
 import type { DayData, UserConfig } from '@/types';
-import { isWeekend, isHoliday, calculateWorkedHours, getTheoreticalHoursForDate } from '@/lib/timeCalculations';
+import { isWeekend, isHoliday, calculateDayWorkedHours, getTheoreticalHoursForDate } from '@/lib/timeCalculations';
 import { format, eachDayOfInterval } from 'date-fns';
 import { CheckCircle, AlertCircle, XCircle } from 'lucide-react';
 
@@ -37,11 +37,11 @@ export function WeeklySummaryIcon({ weekStart, weekEnd, daysData, config, onClic
       totalTheoretical += theoretical;
 
       if (dayData?.dayStatus === 'assumpte_propi') {
-        totalWorked += (dayData.apHours || 0) + calculateWorkedHours(dayData.startTime, dayData.endTime);
+        totalWorked += (dayData.apHours || 0) + calculateDayWorkedHours(dayData);
       } else if (dayData?.dayStatus === 'flexibilitat') {
-        totalWorked += (dayData.flexHours || 0) + calculateWorkedHours(dayData.startTime, dayData.endTime);
+        totalWorked += (dayData.flexHours || 0) + calculateDayWorkedHours(dayData);
       } else {
-        totalWorked += calculateWorkedHours(dayData?.startTime || null, dayData?.endTime || null);
+        totalWorked += calculateDayWorkedHours(dayData);
       }
     }
     
@@ -56,7 +56,10 @@ export function WeeklySummaryIcon({ weekStart, weekEnd, daysData, config, onClic
     }
     
     // Check if laboral day has times
-    if (dayData.dayStatus === 'laboral' && (!dayData.startTime || !dayData.endTime)) {
+    const hasAnyShift = Boolean(
+      (dayData.startTime && dayData.endTime) || (dayData.startTime2 && dayData.endTime2)
+    );
+    if (dayData.dayStatus === 'laboral' && !hasAnyShift) {
       allComplete = false;
     }
   }

--- a/src/lib/timeCalculations.ts
+++ b/src/lib/timeCalculations.ts
@@ -20,6 +20,13 @@ export function calculateWorkedHours(startTime: string | null, endTime: string |
   return Math.max(0, end - start);
 }
 
+export function calculateDayWorkedHours(dayData: DayData | null | undefined): number {
+  if (!dayData) return 0;
+  const primary = calculateWorkedHours(dayData.startTime, dayData.endTime);
+  const secondary = calculateWorkedHours(dayData.startTime2 ?? null, dayData.endTime2 ?? null);
+  return primary + secondary;
+}
+
 export function getDayOfWeekKey(date: Date): keyof WeeklyConfig | null {
   const dayIndex = getDay(date);
   const mapping: Record<number, keyof WeeklyConfig> = {
@@ -100,11 +107,11 @@ export function calculateWeeklySummary(
     
     if (dayData) {
       if (dayData.dayStatus === 'assumpte_propi') {
-        workedHours += (dayData.apHours || 0) + calculateWorkedHours(dayData.startTime, dayData.endTime);
+        workedHours += (dayData.apHours || 0) + calculateDayWorkedHours(dayData);
       } else if (dayData.dayStatus === 'flexibilitat') {
-        workedHours += (dayData.flexHours || 0) + calculateWorkedHours(dayData.startTime, dayData.endTime);
+        workedHours += (dayData.flexHours || 0) + calculateDayWorkedHours(dayData);
       } else {
-        workedHours += calculateWorkedHours(dayData.startTime, dayData.endTime);
+        workedHours += calculateDayWorkedHours(dayData);
       }
     }
   });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -21,6 +21,8 @@ const DayDataSchema = z.object({
   theoreticalHours: z.number().min(0).max(24),
   startTime: z.string().regex(/^\d{2}:\d{2}$/).nullable(),
   endTime: z.string().regex(/^\d{2}:\d{2}$/).nullable(),
+  startTime2: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
+  endTime2: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
   dayType: DayTypeSchema,
   dayStatus: DayStatusSchema,
   requestStatus: RequestStatusSchema,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -8,6 +8,8 @@ export interface DayData {
   theoreticalHours: number;
   startTime: string | null; // HH:mm
   endTime: string | null; // HH:mm
+  startTime2?: string | null; // HH:mm
+  endTime2?: string | null; // HH:mm
   dayType: DayType;
   dayStatus: DayStatus;
   requestStatus: RequestStatus;


### PR DESCRIPTION
### Motivation
- Allow users to record two work intervals per day (split shifts) so e.g. morning and afternoon sessions with a lunch break can be entered and summed for weekly totals.

### Description
- Add optional `startTime2` and `endTime2` fields to `DayData` and update import validation to accept them (`src/types/index.ts`, `src/lib/validation.ts`).
- Add `calculateDayWorkedHours` to sum both shifts and replace single-shift calculations across weekly and summary logic (`src/lib/timeCalculations.ts`).
- Extend the day editor UI to add/remove a second shift with a `+` button and persist the second shift on save (`src/components/Calendar/DayDetailDialog.tsx`).
- Update calendar day, weekly summary dialog and weekly icon to display multiple shifts and to use the new day-level worked-hours calculation (`src/components/Calendar/CalendarDay.tsx`, `src/components/Calendar/WeeklySummaryDialog.tsx`, `src/components/Calendar/WeeklySummaryIcon.tsx`).

### Testing
- Attempted to run `npm install` to run the project/tests but the install failed with a `403 Forbidden` while fetching `@testing-library/jest-dom`, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fedd047f4832780616efd852faa98)