### PR TITLE
Format AP/FX absence hours in calendar overview

### DIFF
--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -77,8 +77,19 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isToday, on
 
   const formatAbsenceHours = (hours: number): string => {
     const h = Math.floor(hours);
-    const m = Math.round((hours % 1) * 60);
-    return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+    let m = Math.round((hours % 1) * 60);
+    let adjustedHours = h;
+    if (m === 60) {
+      adjustedHours += 1;
+      m = 0;
+    }
+    if (adjustedHours > 0 && m > 0) {
+      return `${adjustedHours}h ${m}min`;
+    }
+    if (adjustedHours > 0) {
+      return `${adjustedHours}h`;
+    }
+    return `${m} min`;
   };
 
   const getAbsenceDisplay = () => {


### PR DESCRIPTION
### Motivation
- Improve the calendar overview absence display so short AP/FX values are human-readable (e.g. `AP=00:30` -> `30 min`, `AP=1:12` -> `1h 12min`).

### Description
- Update `formatAbsenceHours` in `src/components/Calendar/CalendarDay.tsx` to render `Xh Ymin` (or hours-only or minutes-only), and handle minute rounding that spills into a full hour.

### Testing
- Attempted to run the dev setup (`npm install` / `npm run dev`) but `npm install` failed due to a 403 from the npm registry, so no automated tests or dev server runs were completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff15c1f788327af092739d7777305)