### PR TITLE
Format AP/FX hours as human-readable durations in calendar and summary

### DIFF
--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -77,8 +77,19 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isToday, on
 
   const formatAbsenceHours = (hours: number): string => {
     const h = Math.floor(hours);
-    const m = Math.round((hours % 1) * 60);
-    return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+    let m = Math.round((hours % 1) * 60);
+    let adjustedHours = h;
+    if (m === 60) {
+      adjustedHours += 1;
+      m = 0;
+    }
+    if (adjustedHours > 0 && m > 0) {
+      return `${adjustedHours}h ${m}min`;
+    }
+    if (adjustedHours > 0) {
+      return `${adjustedHours}h`;
+    }
+    return `${m} min`;
   };
 
   const getAbsenceDisplay = () => {

--- a/src/components/Summary/StatusSummary.tsx
+++ b/src/components/Summary/StatusSummary.tsx
@@ -9,9 +9,27 @@ interface StatusSummaryProps {
 }
 
 export function StatusSummary({ config, variant = 'default' }: StatusSummaryProps) {
+  const formatDuration = (hours: number): string => {
+    const wholeHours = Math.floor(hours);
+    let minutes = Math.round((hours % 1) * 60);
+    let adjustedHours = wholeHours;
+    if (minutes === 60) {
+      adjustedHours += 1;
+      minutes = 0;
+    }
+    if (adjustedHours > 0 && minutes > 0) {
+      return `${adjustedHours}h ${minutes}min`;
+    }
+    if (adjustedHours > 0) {
+      return `${adjustedHours}h`;
+    }
+    return `${minutes} min`;
+  };
+
   const vacationProgress = (config.usedVacationDays / config.totalVacationDays) * 100;
   const apProgress = (config.usedAPHours / config.totalAPHours) * 100;
   const flexProgress = (config.flexibilityHours / 25) * 100;
+  const remainingAPHours = Math.max(0, config.totalAPHours - config.usedAPHours);
   const summaryItems = [
     {
       key: 'vacances',
@@ -28,9 +46,9 @@ export function StatusSummary({ config, variant = 'default' }: StatusSummaryProp
       label: 'Assumptes Propis',
       icon: Clock,
       iconClassName: 'text-primary',
-      value: (config.totalAPHours - config.usedAPHours).toFixed(1),
-      unit: 'hores',
-      detail: `${config.usedAPHours.toFixed(1)} de ${config.totalAPHours} hores utilitzades`,
+      value: formatDuration(remainingAPHours),
+      unit: '',
+      detail: `${formatDuration(config.usedAPHours)} de ${formatDuration(config.totalAPHours)} utilitzades`,
       progress: apProgress,
     },
     {
@@ -38,8 +56,8 @@ export function StatusSummary({ config, variant = 'default' }: StatusSummaryProp
       label: 'Flexibilitat Horària',
       icon: Sparkles,
       iconClassName: 'text-[hsl(var(--status-complete))]',
-      value: config.flexibilityHours.toFixed(1),
-      unit: 'hores',
+      value: formatDuration(config.flexibilityHours),
+      unit: '',
       detail: 'FX solicitades amb validació',
       progress: flexProgress,
     },
@@ -61,7 +79,9 @@ export function StatusSummary({ config, variant = 'default' }: StatusSummaryProp
               </div>
               <div className="text-sm font-semibold text-foreground">
                 {item.value}
-                <span className="text-xs font-normal text-muted-foreground"> {item.unit}</span>
+                {item.unit && (
+                  <span className="text-xs font-normal text-muted-foreground"> {item.unit}</span>
+                )}
               </div>
             </div>
           );
@@ -84,7 +104,9 @@ export function StatusSummary({ config, variant = 'default' }: StatusSummaryProp
                 </CardTitle>
                 <div className="text-base font-semibold">
                   {item.value}
-                  <span className="text-sm font-normal text-muted-foreground"> {item.unit}</span>
+                  {item.unit && (
+                    <span className="text-sm font-normal text-muted-foreground"> {item.unit}</span>
+                  )}
                 </div>
               </div>
               <p className="text-xs text-muted-foreground">{item.detail}</p>


### PR DESCRIPTION
### Motivation
- Improve readability by showing AP and flexibility hour values in human-friendly `Xh Ymin` form instead of raw decimal hours or `HH:MM` when displayed in the UI.
- Ensure minute rounding that becomes a full hour is handled consistently across calendar and summary views.

### Description
- Update `formatAbsenceHours` in `src/components/Calendar/CalendarDay.tsx` to render durations as `Xh Ymin`, `Xh` or `Y min` and to normalize cases where minutes round to `60` by incrementing hours.
- Update `getAbsenceDisplay` in `CalendarDay.tsx` to use the new formatted strings for `AP` and `FX` displays (e.g. `AP = 30 min`, `FX = 1h 12min`).
- Add `formatDuration` helper in `src/components/Summary/StatusSummary.tsx` and use it to format `Assumptes Propis` and `Flexibilitat Horària` values and details, and compute `remainingAPHours` for the displayed remaining AP value.
- Remove redundant `unit` labels when the displayed `value` already includes units so the UI shows compact, readable strings.

### Testing
- No automated tests or build were executed in this environment. 
- Changes were validated by reading updated files and ensuring formatting logic handles minute rounding to a full hour.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff15c1f788327af092739d7777305)