### PR TITLE
Remove last name field from personal settings

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -249,15 +249,6 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                   placeholder="El teu nom"
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="lastName">Cognoms</Label>
-                <Input
-                  id="lastName"
-                  value={localConfig.lastName}
-                  onChange={(e) => setLocalConfig(prev => ({ ...prev, lastName: e.target.value }))}
-                  placeholder="Els teus cognoms"
-                />
-              </div>
             </div>
 
             <div className="grid grid-cols-2 gap-4">


### PR DESCRIPTION
### Motivation
- Simplify the personal settings form to only show the `Nom` field and remove the `Cognoms` field while preserving the same layout width.

### Description
- Deleted the last name input block from `src/components/Settings/SettingsDialog.tsx` so only the `firstName` (`Nom`) field remains in the personal tab.

### Testing
- Attempted to run `npm run dev -- --host 0.0.0.0 --port 4173` which failed in the environment with `vite: not found` so the dev server could not be started.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff4340dbc8327b183034af47aab4c)