### PR TITLE
Remove `lastName` from user config, types, validation and UI

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,7 +10,7 @@ interface HeaderProps {
 
 export function Header({ config, onOpenSettings }: HeaderProps) {
   const userName = config.firstName 
-    ? `${config.firstName} ${config.lastName}`.trim()
+    ? config.firstName
     : 'Usuari';
 
   return (

--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -249,15 +249,6 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                   placeholder="El teu nom"
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="lastName">Cognoms</Label>
-                <Input
-                  id="lastName"
-                  value={localConfig.lastName}
-                  onChange={(e) => setLocalConfig(prev => ({ ...prev, lastName: e.target.value }))}
-                  placeholder="Els teus cognoms"
-                />
-              </div>
             </div>
 
             <div className="grid grid-cols-2 gap-4">

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -18,7 +18,6 @@ export const BARCELONA_HOLIDAYS_2026 = [
 
 export const DEFAULT_USER_CONFIG = {
   firstName: '',
-  lastName: '',
   defaultStartTime: '07:30',
   defaultEndTime: '15:00',
   weeklyConfig: {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -51,7 +51,6 @@ const SchedulePeriodSchema = z.object({
 // Schema for UserConfig
 const UserConfigSchema = z.object({
   firstName: z.string().max(100).default(''),
-  lastName: z.string().max(100).default(''),
   defaultStartTime: z.string().regex(/^\d{2}:\d{2}$/).default('08:00'),
   defaultEndTime: z.string().regex(/^\d{2}:\d{2}$/).default('15:30'),
   weeklyConfig: WeeklyConfigSchema,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -35,7 +35,6 @@ export interface SchedulePeriod {
 
 export interface UserConfig {
   firstName: string;
-  lastName: string;
   defaultStartTime: string;
   defaultEndTime: string;
   weeklyConfig: WeeklyConfig;


### PR DESCRIPTION
### Motivation
- The app should no longer require or expose a `lastName` field and must continue working using only `firstName` for displaying user names and storing defaults.

### Description
- Removed the `Cognoms` input from the personal settings UI in `src/components/Settings/SettingsDialog.tsx` so only `firstName` remains. 
- Simplified header display in `src/components/Header.tsx` to use only `config.firstName` when present. 
- Dropped `lastName` from the default config in `src/lib/constants.ts`. 
- Removed `lastName` from the validation schema in `src/lib/validation.ts` and from the `UserConfig` type in `src/types/index.ts`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff4340dbc8327b183034af47aab4c)