### PR TITLE
Make calendar year configurable and year-aware in UI and config

### DIFF
--- a/src/components/Calendar/CalendarGrid.tsx
+++ b/src/components/Calendar/CalendarGrid.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, startOfWeek, endOfWeek, isSameMonth, isToday, addMonths, subMonths, getDay } from 'date-fns';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -16,9 +16,14 @@ interface CalendarGridProps {
 }
 
 export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProps) {
-  const [currentDate, setCurrentDate] = useState(new Date(2026, 0, 1));
+  const [currentDate, setCurrentDate] = useState(new Date(config.calendarYear, 0, 1));
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [selectedWeek, setSelectedWeek] = useState<{ start: Date; end: Date } | null>(null);
+  const calendarYear = config.calendarYear;
+
+  useEffect(() => {
+    setCurrentDate(new Date(calendarYear, 0, 1));
+  }, [calendarYear]);
 
   const monthStart = startOfMonth(currentDate);
   const monthEnd = endOfMonth(currentDate);
@@ -29,14 +34,14 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
 
   const goToPreviousMonth = () => {
     const newDate = subMonths(currentDate, 1);
-    if (newDate.getFullYear() >= 2026) {
+    if (newDate.getFullYear() >= calendarYear) {
       setCurrentDate(newDate);
     }
   };
 
   const goToNextMonth = () => {
     const newDate = addMonths(currentDate, 1);
-    if (newDate.getFullYear() <= 2026) {
+    if (newDate.getFullYear() <= calendarYear) {
       setCurrentDate(newDate);
     }
   };
@@ -66,7 +71,7 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
           variant="outline"
           size="icon"
           onClick={goToPreviousMonth}
-          disabled={currentDate.getMonth() === 0 && currentDate.getFullYear() === 2026}
+          disabled={currentDate.getMonth() === 0 && currentDate.getFullYear() === calendarYear}
         >
           <ChevronLeft className="h-4 w-4" />
         </Button>
@@ -79,7 +84,7 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
           variant="outline"
           size="icon"
           onClick={goToNextMonth}
-          disabled={currentDate.getMonth() === 11 && currentDate.getFullYear() === 2026}
+          disabled={currentDate.getMonth() === 11 && currentDate.getFullYear() === calendarYear}
         >
           <ChevronRight className="h-4 w-4" />
         </Button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,7 +25,7 @@ export function Header({ config, onOpenSettings }: HeaderProps) {
               <div>
                 <h1 className="text-xl font-bold text-foreground">Control horari</h1>
                 <p className="text-sm text-muted-foreground">
-                  {userName} · 2026
+                  {userName} · {config.calendarYear}
                 </p>
               </div>
             </div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,7 +16,10 @@ export const BARCELONA_HOLIDAYS_2026 = [
   '2026-12-26', // Sant Esteve
 ];
 
+export const DEFAULT_CALENDAR_YEAR = 2026;
+
 export const DEFAULT_USER_CONFIG = {
+  calendarYear: DEFAULT_CALENDAR_YEAR,
   firstName: '',
   defaultStartTime: '07:30',
   defaultEndTime: '15:00',
@@ -30,8 +33,8 @@ export const DEFAULT_USER_CONFIG = {
   schedulePeriods: [
     {
       id: 'default-winter',
-      startDate: '2026-01-01',
-      endDate: '2026-12-31',
+      startDate: `${DEFAULT_CALENDAR_YEAR}-01-01`,
+      endDate: `${DEFAULT_CALENDAR_YEAR}-12-31`,
       scheduleType: 'hivern' as const,
     },
   ],

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -13,6 +13,9 @@ export function getUserConfig(): UserConfig {
       if (!parsed.schedulePeriods) {
         parsed.schedulePeriods = DEFAULT_USER_CONFIG.schedulePeriods;
       }
+      if (typeof parsed.calendarYear !== 'number') {
+        parsed.calendarYear = DEFAULT_USER_CONFIG.calendarYear;
+      }
       // Migrate old weeklyConfig with theoreticalHours
       if (parsed.weeklyConfig && 'theoreticalHours' in (parsed.weeklyConfig.monday || {})) {
         parsed.weeklyConfig = {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -50,6 +50,7 @@ const SchedulePeriodSchema = z.object({
 
 // Schema for UserConfig
 const UserConfigSchema = z.object({
+  calendarYear: z.number().min(1900).max(2200),
   firstName: z.string().max(100).default(''),
   defaultStartTime: z.string().regex(/^\d{2}:\d{2}$/).default('08:00'),
   defaultEndTime: z.string().regex(/^\d{2}:\d{2}$/).default('15:30'),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,7 @@ export interface SchedulePeriod {
 }
 
 export interface UserConfig {
+  calendarYear: number;
   firstName: string;
   defaultStartTime: string;
   defaultEndTime: string;


### PR DESCRIPTION
### Motivation
- Allow the user to set the calendar year in the settings so the app can be used for 2026 and later years. 
- Replace hard-coded 2026 boundaries so schedule periods, holidays and calendar navigation adapt to the configured year.

### Description
- Added `calendarYear: number` to the `UserConfig` type and `DEFAULT_USER_CONFIG`, and introduced `DEFAULT_CALENDAR_YEAR` in `src/lib/constants.ts`.
- Implemented migration in `src/lib/storage.ts` to populate `calendarYear` for older configs and added validation of `calendarYear` in `src/lib/validation.ts`.
- Settings UI (`src/components/Settings/SettingsDialog.tsx`) gains a new `Any del calendari` numeric input and helper functions `getYearBounds`, `shiftDateToYear` and `handleCalendarYearChange` to shift schedule periods and holidays when the year changes, and to apply year-based min/max bounds and schedule coverage validation.
- Calendar view and navigation (`src/components/Calendar/CalendarGrid.tsx`) now initialize from `config.calendarYear` and limit month navigation to the configured year, and the header (`src/components/Header.tsx`) displays the configured year instead of the hard-coded value.

### Testing
- No automated tests were executed; dependency installation failed when attempting to run (`npm install`) due to a `403 Forbidden` error from the npm registry, so a local build/test run could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ff79e6038832799de84cf68103298)