### PR TITLE
Update vacation summary to show pending approvals

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,14 +1,15 @@
 import { Button } from '@/components/ui/button';
 import { StatusSummary } from '@/components/Summary/StatusSummary';
 import { Settings, Clock } from 'lucide-react';
-import type { UserConfig } from '@/types';
+import type { DayData, UserConfig } from '@/types';
 
 interface HeaderProps {
   config: UserConfig;
+  daysData: Record<string, DayData>;
   onOpenSettings: () => void;
 }
 
-export function Header({ config, onOpenSettings }: HeaderProps) {
+export function Header({ config, daysData, onOpenSettings }: HeaderProps) {
   const userName = config.firstName 
     ? config.firstName
     : 'Usuari';
@@ -29,7 +30,7 @@ export function Header({ config, onOpenSettings }: HeaderProps) {
                 </p>
               </div>
             </div>
-            <StatusSummary config={config} variant="compact" />
+            <StatusSummary config={config} daysData={daysData} variant="compact" />
           </div>
 
           <Button

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -23,7 +23,11 @@ const Index = () => {
 
   return (
     <div className="min-h-screen bg-background">
-      <Header config={config} onOpenSettings={() => setSettingsOpen(true)} />
+      <Header
+        config={config}
+        daysData={daysData}
+        onOpenSettings={() => setSettingsOpen(true)}
+      />
       
       <main className="container mx-auto px-4 py-6 space-y-6">
         <CalendarGrid


### PR DESCRIPTION
### Motivation
- The header vacation summary must show the remaining vacation days and indicate how many requested vacation days are still pending approval so users see `(X per aprovar)` next to the total.
- The summary calculations should count requested vacation days (pending + approved) when computing remaining and progress, rather than only using `usedVacationDays`.

### Description
- Updated `StatusSummary` (`src/components/Summary/StatusSummary.tsx`) to accept `daysData` and compute `requestedVacationDays`, `pendingVacationDays`, `remainingVacationDays`, and adjusted `vacationProgress` based on requested days.
- Changed the displayed vacation `value` to show the remaining days plus pending count as `"{remaining} ({pending} per aprovar)"` and updated the `detail` to include approved and pending counts.
- Passed `daysData` through the header by updating `Header` (`src/components/Header.tsx`) and the page entry `Index` (`src/pages/Index.tsx`) so the compact summary has the needed day information.

### Testing
- Attempted `npm install` to run the dev/build, but the command failed with a `403 Forbidden` from the npm registry so UI/server tests could not be started.
- No automated tests were executed after the changes due to the package install failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696ffd597530832783641763c9aba5b7)