### PR TITLE
Allow 1-minute increments for AP/FX absence inputs

### DIFF
--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -391,6 +391,7 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
                     type="number"
                     min="0"
                     max={absenceType === 'flexibilitat' ? Math.floor(maxFlexHours) : Math.floor(theoreticalHours)}
+                    step="1"
                     value={absenceHours}
                     onChange={(e) => {
                       setAbsenceHours(parseInt(e.target.value) || 0);
@@ -407,7 +408,7 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
                     type="number"
                     min="0"
                     max="59"
-                    step="5"
+                    step="1"
                     value={absenceMinutes}
                     onChange={(e) => {
                       setAbsenceMinutes(parseInt(e.target.value) || 0);


### PR DESCRIPTION
### Motivation
- Enable adjusting AP (`assumpte_propi`) and FX (`flexibilitat`) absence durations one unit at a time using the input arrow controls to match user expectation for precise minute edits.

### Description
- Set `step="1"` on the `absenceHours` and `absenceMinutes` `<Input>` fields in `src/components/Calendar/DayDetailDialog.tsx` so hours and minutes increment by 1 (minutes were previously stepping by 5).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971000a5d788327aec6b381b2a824d4)