### PR TITLE
Format worked hours as "Xh Ymin" in weekly summary

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -10,7 +10,8 @@ import {
   calculateDayWorkedHours, 
   isHoliday, 
   isWeekend,
-  formatHoursDisplay 
+  formatHoursDisplay,
+  formatHoursMinutes
 } from '@/lib/timeCalculations';
 import { DAY_NAMES_CA, MONTH_NAMES_CA } from '@/lib/constants';
 import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check } from 'lucide-react';
@@ -211,7 +212,7 @@ export function WeeklySummaryDialog({
                     </div>
                     <div className="space-y-1">
                       <p className="text-muted-foreground">Hores treballades</p>
-                      <p className="font-medium">{formatHours(summaryWorked)}</p>
+                      <p className="font-medium">{formatHoursMinutes(summaryWorked)}</p>
                       {extraHours > 0 && (
                         <p className="text-xs text-muted-foreground">
                           +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
@@ -240,7 +241,7 @@ export function WeeklySummaryDialog({
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Hores treballades</p>
-                <p className="text-2xl font-bold">{totalWorked.toFixed(1)}h</p>
+                <p className="text-2xl font-bold">{formatHoursMinutes(totalWorked)}</p>
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Diferència</p>

--- a/src/lib/timeCalculations.ts
+++ b/src/lib/timeCalculations.ts
@@ -138,3 +138,10 @@ export function formatHoursDisplay(hours: number): string {
   const sign = hours < 0 ? '-' : '+';
   return `${sign}${h}h ${m}min`;
 }
+
+export function formatHoursMinutes(hours: number): string {
+  const totalMinutes = Math.round(Math.abs(hours) * 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return `${h}h ${m}min`;
+}


### PR DESCRIPTION
### Motivation

- Display worked hours in the Weekly Summary using a human-friendly `Xh Ymin` format instead of decimal hours to match the UI requirement.

### Description

- Added `formatHoursMinutes` in `src/lib/timeCalculations.ts` to format numeric hour values as `Xh Ymin` with minute rounding.
- Imported and used `formatHoursMinutes` in `src/components/Calendar/WeeklySummaryDialog.tsx` to render daily `Hores treballades` and the weekly total `Hores treballades`.
- Kept existing `formatHoursDisplay` for signed difference values and left theoretical hours display unchanged.

### Testing

- Attempted to run the dev server with `npm run dev`, which failed because `vite` was not available in the environment (command error). 
- Attempted to install dependencies with `npm install`, which failed with a `403 Forbidden` error from the registry, so no UI or automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697106a93e3483278337a3a4644e8af7)