### PR TITLE
Format AP/FX extra hours and weekly totals as `Xh Ymin` in weekly summary

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -10,7 +10,8 @@ import {
   calculateDayWorkedHours, 
   isHoliday, 
   isWeekend,
-  formatHoursDisplay 
+  formatHoursDisplay,
+  formatHoursMinutes
 } from '@/lib/timeCalculations';
 import { DAY_NAMES_CA, MONTH_NAMES_CA } from '@/lib/constants';
 import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check } from 'lucide-react';
@@ -106,8 +107,6 @@ export function WeeklySummaryDialog({
       : 'bg-[hsl(var(--status-deficit)/0.15)] border-[hsl(var(--status-deficit)/0.4)]';
   };
 
-  const formatHours = (hours: number) => `${hours.toFixed(1)}h`;
-
   const getScheduleDisplay = (dayData: DayData | undefined) => {
     if (!dayData) return [];
     const shifts: string[] = [];
@@ -171,7 +170,7 @@ export function WeeklySummaryDialog({
                       {getDayName(day)}, {format(day, 'd')}
                     </div>
                     <div className="flex flex-wrap gap-2">
-                      <Badge variant="outline">{formatHours(summaryTheoretical)}</Badge>
+                      <Badge variant="outline">{formatHoursMinutes(summaryTheoretical)}</Badge>
                       <Badge variant={dayType === 'presencial' ? 'default' : 'secondary'} className="text-xs">
                         <DayIcon className="w-3 h-3 mr-1" />
                         {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
@@ -211,10 +210,10 @@ export function WeeklySummaryDialog({
                     </div>
                     <div className="space-y-1">
                       <p className="text-muted-foreground">Hores treballades</p>
-                      <p className="font-medium">{formatHours(summaryWorked)}</p>
+                      <p className="font-medium">{formatHoursMinutes(summaryWorked)}</p>
                       {extraHours > 0 && (
                         <p className="text-xs text-muted-foreground">
-                          +{extraHours.toFixed(1)}h {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
+                          +{formatHoursMinutes(extraHours)} {dayData?.dayStatus === 'assumpte_propi' ? 'AP' : 'FX'}
                         </p>
                       )}
                     </div>
@@ -236,11 +235,11 @@ export function WeeklySummaryDialog({
             <div className="grid grid-cols-3 gap-4 text-center">
               <div>
                 <p className="text-sm text-muted-foreground">Hores teòriques</p>
-                <p className="text-2xl font-bold">{totalTheoretical.toFixed(1)}h</p>
+                <p className="text-2xl font-bold">{formatHoursMinutes(totalTheoretical)}</p>
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Hores treballades</p>
-                <p className="text-2xl font-bold">{totalWorked.toFixed(1)}h</p>
+                <p className="text-2xl font-bold">{formatHoursMinutes(totalWorked)}</p>
               </div>
               <div>
                 <p className="text-sm text-muted-foreground">Diferència</p>

--- a/src/lib/timeCalculations.ts
+++ b/src/lib/timeCalculations.ts
@@ -138,3 +138,10 @@ export function formatHoursDisplay(hours: number): string {
   const sign = hours < 0 ? '-' : '+';
   return `${sign}${h}h ${m}min`;
 }
+
+export function formatHoursMinutes(hours: number): string {
+  const totalMinutes = Math.round(Math.abs(hours) * 60);
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return `${h}h ${m}min`;
+}


### PR DESCRIPTION
### Motivation
- Ensure all hour displays in the weekly summary use the human-friendly `Xh Ymin` format, including AP/FX extra hours, daily worked hours, and weekly totals.

### Description
- Added `formatHoursMinutes` in `src/lib/timeCalculations.ts` to render a numeric hour value as an absolute `Xh Ymin` string.
- Updated `src/components/Calendar/WeeklySummaryDialog.tsx` to import and use `formatHoursMinutes` for daily theoretical badges, daily worked hours, AP/FX extra-hours labels, and the weekly totals, replacing prior `.toFixed(1)h` and the local decimal formatter.
- Kept `formatHoursDisplay` for signed deltas so positive/negative differences remain prefixed.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697106a93e3483278337a3a4644e8af7)