### PR TITLE
Account for approved AP/FX hours when setting calendar day status

### DIFF
--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -33,7 +33,13 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isToday, on
     
     // AP or FX with approval status
     if (dayData?.dayStatus === 'assumpte_propi' || dayData?.dayStatus === 'flexibilitat') {
-      if (dayData.requestStatus === 'aprovat') {
+      const worked = calculateDayWorkedHours(dayData);
+      const theoretical = getTheoreticalHoursForDate(date, config);
+      const extraHours = dayData.dayStatus === 'assumpte_propi'
+        ? (dayData.apHours || 0)
+        : (dayData.flexHours || 0);
+      const totalWorked = worked + extraHours;
+      if (dayData.requestStatus === 'aprovat' && totalWorked >= theoretical) {
         return 'bg-[hsl(var(--status-complete))] text-[hsl(var(--status-complete-foreground))]';
       }
       return 'bg-[hsl(var(--status-deficit))] text-[hsl(var(--status-deficit-foreground))]';


### PR DESCRIPTION
### Motivation
- Ensure days with approved absences (`assumpte_propi` / `flexibilitat`) are shown as complete only when the sum of worked time plus approved AP/FX hours meets the theoretical hours for that day.

### Description
- Updated `src/components/Calendar/CalendarDay.tsx` to compute `totalWorked = calculateDayWorkedHours(dayData) + (apHours|flexHours)` and require `totalWorked >= getTheoreticalHoursForDate(date, config)` along with `requestStatus === 'aprovat'` before applying the complete (green) styling; otherwise the day remains deficit (orange).

### Testing
- Attempted to run the app with `npm run dev -- --host 0.0.0.0 --port 4173`, but the dev server could not start because `vite` was not available in the environment (failed to run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724745160083279f4fc7e0aab447bc)