### PR TITLE
Move legend icon into header controls

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { Legend } from '@/components/Legend';
 import { StatusSummary } from '@/components/Summary/StatusSummary';
 import { Settings, Clock } from 'lucide-react';
 import type { DayData, UserConfig } from '@/types';
@@ -33,14 +34,17 @@ export function Header({ config, daysData, onOpenSettings }: HeaderProps) {
             <StatusSummary config={config} daysData={daysData} variant="compact" />
           </div>
 
-          <Button
-            variant="outline"
-            size="icon"
-            onClick={onOpenSettings}
-            aria-label="Configuració"
-          >
-            <Settings className="w-4 h-4" />
-          </Button>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={onOpenSettings}
+              aria-label="Configuració"
+            >
+              <Settings className="w-4 h-4" />
+            </Button>
+            <Legend />
+          </div>
         </div>
       </div>
     </header>

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,17 +1,14 @@
 import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check, Info } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Button } from '@/components/ui/button';
 
 export function Legend() {
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <button
-          type="button"
-          className="inline-flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2 text-sm font-semibold text-foreground shadow-sm transition hover:bg-accent"
-        >
+        <Button type="button" variant="outline" size="icon" aria-label="Llegenda">
           <Info className="h-4 w-4" />
-          Llegenda
-        </button>
+        </Button>
       </PopoverTrigger>
       <PopoverContent className="w-80 p-4">
         <h3 className="text-sm font-semibold mb-3 text-foreground">Llegenda</h3>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import { Header } from '@/components/Header';
 import { CalendarGrid } from '@/components/Calendar/CalendarGrid';
-import { Legend } from '@/components/Legend';
 import { SettingsDialog } from '@/components/Settings/SettingsDialog';
 import { useTimeTracking } from '@/hooks/useTimeTracking';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -36,7 +35,6 @@ const Index = () => {
           onDayUpdate={updateDayData}
         />
         
-        <Legend />
       </main>
 
       <SettingsDialog


### PR DESCRIPTION
### Motivation
- Place the legend trigger next to the settings control in the header as an icon-only button to free up space in the main layout and match the header control styling.

### Description
- Replace the inline legend trigger in `src/components/Legend.tsx` with the `Button` component configured as an icon-only outline button (`variant="outline" size="icon" aria-label="Llegenda"`).
- Import and add the `Legend` component into the header action group in `src/components/Header.tsx` and wrap settings + legend in a `div` with `flex items-center gap-2` for proper alignment.
- Remove the standalone `<Legend />` placement from the main content in `src/pages/Index.tsx` so the legend is only accessible from the header.

### Testing
- Attempted to start the dev server with `npm run dev`, but `vite` was not found because dependencies were not installed successfully.
- `npm install --no-audit --no-fund` failed with a `403 Forbidden` from `registry.npmjs.org`, so no automated build or runtime tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972482f95a8832797a8cc96769e3882)