### PR TITLE
Tighten spacing in compact status summary

### DIFF
--- a/src/components/Summary/StatusSummary.tsx
+++ b/src/components/Summary/StatusSummary.tsx
@@ -123,7 +123,7 @@ export function StatusSummary({ config, daysData, variant = 'default' }: StatusS
           return (
             <div
               key={item.key}
-              className="flex items-center gap-3 rounded-lg border border-border bg-card/60 px-3 py-2 shadow-sm"
+              className="flex items-center gap-2 rounded-lg border border-border bg-card/60 px-3 py-2 shadow-sm"
             >
               <div className="flex items-center gap-2">
                 <Icon className={`w-4 h-4 ${item.iconClassName}`} />


### PR DESCRIPTION
### Motivation
- Reduce horizontal gap between the label and value in the compact status summary so numbers appear closer to their labels.

### Description
- Replace Tailwind spacing utility `gap-3` with `gap-2` for the compact summary chip container in `src/components/Summary/StatusSummary.tsx`.

### Testing
- Attempted to run `npm install` to boot the app and run tests, but it failed with a `403` from the npm registry so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724aba9f3c8327a821cc5c91cbe27e)