### PR TITLE
Update browser tab title to 'Control horari'

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <!-- TODO: Set the document title to the name of your application -->
-    <title>Lovable App</title>
+    <title>Control horari</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />
 


### PR DESCRIPTION
### Motivation
- Show the correct application name in the browser tab by setting the HTML title to ` <title>Control horari</title> `.

### Description
- Replace the placeholder title in `index.html` with ` <title>Control horari</title> ` so the tab displays "Control horari".

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724c278224832787c1cfe0f1726a9f)