### PR TITLE
Remove Laboral badge from weekly summary days

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -158,6 +158,7 @@ export function WeeklySummaryDialog({
             const statusLabel = getDayStatusLabel(dayData, holiday);
             const statusCardClass = getStatusCardClass(dayData, holiday, worked, theoretical);
             const schedule = getScheduleDisplay(dayData);
+            const showStatusBadge = statusLabel !== 'Laboral';
             
             return (
               <div
@@ -175,10 +176,12 @@ export function WeeklySummaryDialog({
                         <DayIcon className="w-3 h-3 mr-1" />
                         {dayType === 'presencial' ? 'Presencial' : 'Teletreball'}
                       </Badge>
-                      <Badge variant="outline" className="text-xs flex items-center gap-1">
-                        {StatusIcon && <StatusIcon className="w-3 h-3" />}
-                        {statusLabel}
-                      </Badge>
+                      {showStatusBadge && (
+                        <Badge variant="outline" className="text-xs flex items-center gap-1">
+                          {StatusIcon && <StatusIcon className="w-3 h-3" />}
+                          {statusLabel}
+                        </Badge>
+                      )}
                       {dayData?.requestStatus === 'aprovat' && (
                         <Badge variant="outline" className="text-xs flex items-center gap-1">
                           <Check className="w-3 h-3" />


### PR DESCRIPTION
### Motivation
- The weekly summary displayed an always-present `Laboral` status badge that did not add information, so it should be hidden and only meaningful day-status badges should be shown.

### Description
- Conditionally render the status `Badge` in `src/components/Calendar/WeeklySummaryDialog.tsx` by adding `const showStatusBadge = statusLabel !== 'Laboral'` and only rendering the badge when `showStatusBadge` is true.

### Testing
- Attempted to run dependency install and automated tests, but `npm install` failed with a `403 Forbidden` error against `registry.npmjs.org`, so `vitest` was not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724d5de0948327b5d7f7bb6265c303)