### PR TITLE
Remove theoreticalHours from exported day data

### DIFF
--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -175,7 +175,6 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
       : undefined;
     const newDayData: DayData = {
       date: format(date, 'yyyy-MM-dd'),
-      theoreticalHours,
       startTime: absenceType === 'vacances' ? null : (startTime || null),
       endTime: absenceType === 'vacances' ? null : (endTime || null),
       startTime2: absenceType === 'vacances' ? null : (startTime2 || null),

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -84,9 +84,17 @@ export interface ExportData {
 }
 
 export function exportAllData(): ExportData {
+  const daysData = getDaysData();
+  const sanitizedDaysData = Object.fromEntries(
+    Object.entries(daysData).map(([date, dayData]) => {
+      const { theoreticalHours: _unused, ...rest } = dayData as DayData & { theoreticalHours?: number };
+      return [date, rest];
+    })
+  );
+
   return {
     config: getUserConfig(),
-    daysData: getDaysData(),
+    daysData: sanitizedDaysData,
     exportDate: new Date().toISOString(),
     version: '1.0',
   };
@@ -96,7 +104,13 @@ export function importAllData(data: ExportData): boolean {
   try {
     if (data.config && data.daysData) {
       saveUserConfig(data.config);
-      saveDaysData(data.daysData);
+      const sanitizedDaysData = Object.fromEntries(
+        Object.entries(data.daysData).map(([date, dayData]) => {
+          const { theoreticalHours: _unused, ...rest } = dayData as DayData & { theoreticalHours?: number };
+          return [date, rest];
+        })
+      ) as Record<string, DayData>;
+      saveDaysData(sanitizedDaysData);
       return true;
     }
     return false;

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -18,7 +18,7 @@ const ScheduleTypeSchema = z.enum(['hivern', 'estiu']);
 // Schema for DayData
 const DayDataSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format'),
-  theoreticalHours: z.number().min(0).max(24),
+  theoreticalHours: z.number().min(0).max(24).optional(),
   startTime: z.string().regex(/^\d{2}:\d{2}$/).nullable(),
   endTime: z.string().regex(/^\d{2}:\d{2}$/).nullable(),
   startTime2: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -5,7 +5,6 @@ export type ScheduleType = 'hivern' | 'estiu';
 
 export interface DayData {
   date: string; // YYYY-MM-DD
-  theoreticalHours: number;
   startTime: string | null; // HH:mm
   endTime: string | null; // HH:mm
   startTime2?: string | null; // HH:mm


### PR DESCRIPTION
### Motivation
- Exports were including `theoreticalHours` on each `DayData` record, which is redundant because theoretical hours are derived from schedule configuration and schedule periods.
- Keep exported files minimal and avoid persisting a derived value that can get out of sync with current config.
- Allow importing older exports that may still contain `theoreticalHours` without breaking validation.

### Description
- Removed the `theoreticalHours` property from the `DayData` type so it is no longer persisted in day records (`src/types/index.ts`).
- Stopped writing `theoreticalHours` when saving day details in the UI by removing it from the payload constructed in `DayDetailDialog` (`src/components/Calendar/DayDetailDialog.tsx`).
- Stripped `theoreticalHours` from day entries during export in `exportAllData` and from incoming records during `importAllData` to sanitize files (`src/lib/storage.ts`).
- Made `theoreticalHours` optional in the import validation schema so older exports that include it are still accepted (`src/lib/validation.ts`).

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69724ecf2d4883278e40bd35b224a737)