### PR TITLE
Omit null times from exports

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -76,9 +76,16 @@ export function saveDayData(dayData: DayData): void {
   saveDaysData(allDays);
 }
 
+type ExportDayData = Omit<DayData, 'startTime' | 'endTime' | 'startTime2' | 'endTime2'> & {
+  startTime?: string | null;
+  endTime?: string | null;
+  startTime2?: string | null;
+  endTime2?: string | null;
+};
+
 export interface ExportData {
   config: UserConfig;
-  daysData: Record<string, DayData>;
+  daysData: Record<string, ExportDayData>;
   exportDate: string;
   version: string;
 }
@@ -88,7 +95,14 @@ export function exportAllData(): ExportData {
   const sanitizedDaysData = Object.fromEntries(
     Object.entries(daysData).map(([date, dayData]) => {
       const { theoreticalHours: _unused, ...rest } = dayData as DayData & { theoreticalHours?: number };
-      return [date, rest];
+      const cleaned: ExportDayData = { ...rest };
+
+      if (cleaned.startTime === null) delete cleaned.startTime;
+      if (cleaned.endTime === null) delete cleaned.endTime;
+      if (cleaned.startTime2 == null) delete cleaned.startTime2;
+      if (cleaned.endTime2 == null) delete cleaned.endTime2;
+
+      return [date, cleaned];
     })
   );
 
@@ -107,7 +121,14 @@ export function importAllData(data: ExportData): boolean {
       const sanitizedDaysData = Object.fromEntries(
         Object.entries(data.daysData).map(([date, dayData]) => {
           const { theoreticalHours: _unused, ...rest } = dayData as DayData & { theoreticalHours?: number };
-          return [date, rest];
+          const normalized: DayData = {
+            ...rest,
+            startTime: rest.startTime ?? null,
+            endTime: rest.endTime ?? null,
+            startTime2: rest.startTime2 ?? null,
+            endTime2: rest.endTime2 ?? null,
+          };
+          return [date, normalized];
         })
       ) as Record<string, DayData>;
       saveDaysData(sanitizedDaysData);

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -19,8 +19,8 @@ const ScheduleTypeSchema = z.enum(['hivern', 'estiu']);
 const DayDataSchema = z.object({
   date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'Invalid date format'),
   theoreticalHours: z.number().min(0).max(24).optional(),
-  startTime: z.string().regex(/^\d{2}:\d{2}$/).nullable(),
-  endTime: z.string().regex(/^\d{2}:\d{2}$/).nullable(),
+  startTime: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
+  endTime: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
   startTime2: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
   endTime2: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
   dayType: DayTypeSchema,


### PR DESCRIPTION
### Motivation

- Avoid exporting time fields that are `null` so exported JSON is cleaner and omits unnecessary keys.
- Ensure imports remain compatible by normalizing omitted or missing time fields back to `null` for internal use.
- Allow exported files to omit the primary `startTime`/`endTime` fields in validation so imports of trimmed exports succeed.

### Description

- Made `startTime` and `endTime` optional in the `DayData` validation schema by changing them to `nullable().optional()` in `src/lib/validation.ts`.
- Introduced an `ExportDayData` type and updated `ExportData` to use `Record<string, ExportDayData>` in `src/lib/storage.ts`.
- Updated `exportAllData()` to remove `startTime`, `endTime`, `startTime2`, and `endTime2` properties when they are `null` (or `null`/`undefined` for second shift) before producing the export payload.
- Updated `importAllData()` to normalize possibly-missing time fields back to `null` (`startTime`, `endTime`, `startTime2`, `endTime2`) when reconstructing stored `DayData`.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69725104b390832793b48d3fa8cffec8)