### PR TITLE
Remove dayType from export payloads

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -23,7 +23,7 @@ const DayDataSchema = z.object({
   endTime: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
   startTime2: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
   endTime2: z.string().regex(/^\d{2}:\d{2}$/).nullable().optional(),
-  dayType: DayTypeSchema,
+  dayType: DayTypeSchema.optional(),
   dayStatus: DayStatusSchema,
   requestStatus: RequestStatusSchema,
   apHours: z.number().min(0).max(24).optional(),


### PR DESCRIPTION
### Motivation
- The exported day entries included `dayType` which is redundant because the weekly schedule is defined in `weeklyConfig`, so exports should omit it to avoid duplication.
- Imports must remain backward-compatible for older files that may still include `dayType`, so missing values should be inferred on import.

### Description
- Updated `src/lib/storage.ts` to omit `dayType` from the exported `ExportDayData` payload and stop including it when sanitizing day records for export.
- During `importAllData` the code now infers a missing `dayType` by calling `getDayTypeForDate(parseISO(date), data.config)` and assigns it to the normalized `DayData` entries.
- Added imports and type updates in `src/lib/storage.ts` for `DayType`, `getDayTypeForDate` and `parseISO` to support the inference logic.
- Relaxed the import validation schema in `src/lib/validation.ts` by making `dayType` optional in the `DayData` schema so exported files without `dayType` pass validation.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697254062a8483279c0a96898d0f2455)