### PR TITLE
Omit null requestStatus from exports and relax import validation

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -78,12 +78,13 @@ export function saveDayData(dayData: DayData): void {
   saveDaysData(allDays);
 }
 
-type ExportDayData = Omit<DayData, 'startTime' | 'endTime' | 'startTime2' | 'endTime2' | 'dayType'> & {
+type ExportDayData = Omit<DayData, 'startTime' | 'endTime' | 'startTime2' | 'endTime2' | 'dayType' | 'requestStatus'> & {
   startTime?: string | null;
   endTime?: string | null;
   startTime2?: string | null;
   endTime2?: string | null;
   dayType?: DayType;
+  requestStatus?: DayData['requestStatus'];
 };
 
 export interface ExportData {
@@ -97,7 +98,7 @@ export function exportAllData(): ExportData {
   const daysData = getDaysData();
   const sanitizedDaysData = Object.fromEntries(
     Object.entries(daysData).map(([date, dayData]) => {
-      const { theoreticalHours: _unused, dayType: _dayType, ...rest } = dayData as DayData & {
+      const { theoreticalHours: _unused, dayType: _dayType, requestStatus, ...rest } = dayData as DayData & {
         theoreticalHours?: number;
       };
       const cleaned: ExportDayData = { ...rest };
@@ -106,6 +107,9 @@ export function exportAllData(): ExportData {
       if (cleaned.endTime === null) delete cleaned.endTime;
       if (cleaned.startTime2 == null) delete cleaned.startTime2;
       if (cleaned.endTime2 == null) delete cleaned.endTime2;
+      if (requestStatus != null) {
+        cleaned.requestStatus = requestStatus;
+      }
 
       return [date, cleaned];
     })
@@ -132,6 +136,7 @@ export function importAllData(data: ExportData): boolean {
             endTime: rest.endTime ?? null,
             startTime2: rest.startTime2 ?? null,
             endTime2: rest.endTime2 ?? null,
+            requestStatus: rest.requestStatus ?? null,
             dayType: rest.dayType ?? getDayTypeForDate(parseISO(date), data.config),
           };
           return [date, normalized];

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -10,7 +10,7 @@ const DayTypeSchema = z.enum(['presencial', 'teletreball']);
 const DayStatusSchema = z.enum(['laboral', 'festiu', 'vacances', 'assumpte_propi', 'flexibilitat']);
 
 // Schema for RequestStatus
-const RequestStatusSchema = z.enum(['pendent', 'aprovat']).nullable();
+const RequestStatusSchema = z.enum(['pendent', 'aprovat']).nullable().optional();
 
 // Schema for ScheduleType
 const ScheduleTypeSchema = z.enum(['hivern', 'estiu']);


### PR DESCRIPTION
### Motivation
- Avoid including `requestStatus` in exported JSON when its value is `null` so exported files are cleaner and compatible with older imports.
- Allow exported files that omit `requestStatus` to still pass validation and rehydrate runtime data consistently.

### Description
- Updated the export type `ExportDayData` to treat `requestStatus` as optional and adjusted `exportAllData` to destructure `requestStatus` and only add it to the cleaned export object when it is non-null.
- Changed the `RequestStatus` validation schema in `src/lib/validation.ts` to be optional (`.nullable().optional()`) so missing fields validate.
- Ensured `importAllData` normalizes a missing `requestStatus` to `null` at runtime so `DayData` instances always have the field set.
- Applied changes in `src/lib/storage.ts` and `src/lib/validation.ts` to implement the above behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697255c47bb48327a857250e52882cf0)