### PR TITLE
Filter null/undefined day records before saving to localStorage

### DIFF
--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -59,9 +59,12 @@ export function getDaysData(): Record<string, DayData> {
   return {};
 }
 
-export function saveDaysData(data: Record<string, DayData>): void {
+export function saveDaysData(data: Record<string, DayData | null | undefined>): void {
   try {
-    localStorage.setItem(DAYS_DATA_KEY, JSON.stringify(data));
+    const sanitized = Object.fromEntries(
+      Object.entries(data).filter(([, value]) => value != null)
+    ) as Record<string, DayData>;
+    localStorage.setItem(DAYS_DATA_KEY, JSON.stringify(sanitized));
   } catch (error) {
     console.error('Error saving days data:', error);
   }


### PR DESCRIPTION
### Motivation
- Prevent storing `null`/`undefined` day entries in browser `localStorage` for `DAYS_DATA_KEY` to keep persisted days data clean and avoid saving empty records.

### Description
- Update `src/lib/storage.ts` to change `saveDaysData` signature to accept `Record<string, DayData | null | undefined>` and sanitize input by removing entries with `null`/`undefined` values before calling `localStorage.setItem`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739da1437083278474f45563a676de)