### PR TITLE
Sanitize and normalize day data in storage; infer dayType/status on load

### DIFF
--- a/src/hooks/useTimeTracking.ts
+++ b/src/hooks/useTimeTracking.ts
@@ -13,7 +13,7 @@ export function useTimeTracking() {
 
   useEffect(() => {
     const loadedConfig = getUserConfig();
-    const loadedDays = getDaysData();
+    const loadedDays = getDaysData(loadedConfig);
     setConfig(loadedConfig);
     setDaysData(loadedDays);
     previousDaysDataRef.current = loadedDays;


### PR DESCRIPTION
### Motivation
- Avoid persisting redundant or null day fields in browser `localStorage` by only saving meaningful absence data (e.g. vacations or non-null hours) and derive `dayType` from the user configuration instead of storing it per-day.
- Skills used: none (no repo-level skills were required for this change).

### Description
- Added `inferDayStatus`, `normalizeDayData`, and `sanitizeDayDataForStorage` helpers to infer `dayStatus`, fill defaults, and produce a compact representation for storage respectively.
- Changed `getDaysData` to accept an optional `config` (`getUserConfig()` by default) and to `normalizeDayData` when reading stored values so `dayType` and missing fields are derived from config instead of being stored.
- Updated `saveDaysData` to sanitize entries and skip saving days that would only contain null/empty fields, and to avoid storing `dayType` for regular (laborable) days (only keep `dayStatus` when it is `vacances` or other meaningful fields are present).
- Updated `exportAllData` to load days via the resolved config and updated `useTimeTracking` to call `getDaysData(loadedConfig)` so loaded days use the active configuration.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a202a91c8327a9c29856090087dd)