### PR TITLE
Add authorship tab to settings

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -9,7 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { X, Plus, Download, Upload, Trash2, AlertTriangle, AlertCircle, Info } from 'lucide-react';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import type { UserConfig, DayType, SchedulePeriod, ScheduleType } from '@/types';
-import { DAYS_OF_WEEK, DAY_NAMES_CA, MONTH_NAMES_CA, SCHEDULE_HOURS } from '@/lib/constants';
+import { APP_INFO, DAYS_OF_WEEK, DAY_NAMES_CA, MONTH_NAMES_CA, SCHEDULE_HOURS } from '@/lib/constants';
 import { format, parseISO, eachDayOfInterval, isWithinInterval, endOfMonth } from 'date-fns';
 import { exportAllData, importAllData, resetAllData, type ExportData } from '@/lib/storage';
 import { safeValidateExportData, MAX_IMPORT_FILE_SIZE } from '@/lib/validation';
@@ -269,11 +269,12 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
         </DialogHeader>
 
         <Tabs defaultValue="personal" className="w-full">
-          <TabsList className="grid w-full grid-cols-4">
+          <TabsList className="grid w-full grid-cols-5">
             <TabsTrigger value="personal">Personal</TabsTrigger>
             <TabsTrigger value="schedule">Horari</TabsTrigger>
             <TabsTrigger value="holidays">Festius</TabsTrigger>
             <TabsTrigger value="data">Dades</TabsTrigger>
+            <TabsTrigger value="authorship">Autoria</TabsTrigger>
           </TabsList>
 
           <TabsContent value="personal" className="space-y-4 pt-4">
@@ -561,6 +562,39 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 </AlertDialogContent>
               </AlertDialog>
             </div>
+          </TabsContent>
+
+          <TabsContent value="authorship" className="space-y-6 pt-4">
+            <div className="space-y-1">
+              <h3 className="text-lg font-semibold">Detalls del projecte</h3>
+              <p className="text-sm text-muted-foreground">
+                Informació bàsica sobre el programa i la seva autoria.
+              </p>
+            </div>
+            <dl className="grid gap-3 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border pb-3">
+                <dt className="text-muted-foreground">Nom del programa</dt>
+                <dd className="font-medium text-right">{APP_INFO.name}</dd>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border pb-3">
+                <dt className="text-muted-foreground">Autor</dt>
+                <dd className="font-medium text-right">{APP_INFO.author}</dd>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border pb-3">
+                <dt className="text-muted-foreground">Llicència</dt>
+                <dd className="font-medium text-right">
+                  <Badge variant="outline">{APP_INFO.license}</Badge>
+                </dd>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border pb-3">
+                <dt className="text-muted-foreground">Any</dt>
+                <dd className="font-medium text-right">{APP_INFO.year}</dd>
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <dt className="text-muted-foreground">Versió</dt>
+                <dd className="font-medium text-right">{APP_INFO.version}</dd>
+              </div>
+            </dl>
           </TabsContent>
         </Tabs>
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -71,3 +71,11 @@ export const MONTH_NAMES_CA = [
 
 export const MAX_FLEXIBILITY_HOURS = 25;
 export const MIN_WEEKLY_SURPLUS_FOR_FLEXIBILITY = 0.5; // 30 minutes
+
+export const APP_INFO = {
+  name: 'Control horari Educació',
+  author: 'Rafa Barrachina',
+  license: 'Apache License 2.0',
+  year: 2026,
+  version: '1.0',
+};


### PR DESCRIPTION
### Motivation
- Surface basic program metadata in the app settings so users can see program name, author, license, year and version in a dedicated place.
- Provide a single source of truth for app metadata to be reused across the UI via a shared constant.

### Description
- Add `APP_INFO` to `src/lib/constants.ts` with `name`, `author`, `license`, `year` and `version` fields.
- Extend `src/components/Settings/SettingsDialog.tsx` to import `APP_INFO`, increase the tabs grid to five columns and add a new `Autoria` tab displaying the app metadata (name, author, license shown in a `Badge`, year and version).
- Keep the metadata display read-only and purely informational (no changes to persistence or config storage).

### Testing
- Attempted dependency install with `npm install`, but it failed with a `403 Forbidden` against the registry so no automated tests or dev server were run; therefore no test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973a4638c648327a1e679a072fb16e4)