### PR TITLE
Inline AP hours in Assumtes Propis dialog lists

### DIFF
--- a/src/components/Summary/StatusSummary.tsx
+++ b/src/components/Summary/StatusSummary.tsx
@@ -15,6 +15,7 @@ interface StatusSummaryProps {
 
 export function StatusSummary({ config, daysData, variant = 'default' }: StatusSummaryProps) {
   const [vacationDialogOpen, setVacationDialogOpen] = useState(false);
+  const [apDialogOpen, setApDialogOpen] = useState(false);
   const formatDuration = (hours: number): string => {
     const wholeHours = Math.floor(hours);
     let minutes = Math.round((hours % 1) * 60);
@@ -95,10 +96,23 @@ export function StatusSummary({ config, daysData, variant = 'default' }: StatusS
       .sort((a, b) => parseISO(a.date).getTime() - parseISO(b.date).getTime()),
     [daysData]
   );
+  const pendingAPDaysList = useMemo(
+    () => Object.values(daysData)
+      .filter((day) => day.dayStatus === 'assumpte_propi' && day.requestStatus === 'pendent')
+      .sort((a, b) => parseISO(a.date).getTime() - parseISO(b.date).getTime()),
+    [daysData]
+  );
+  const approvedAPDaysList = useMemo(
+    () => Object.values(daysData)
+      .filter((day) => day.dayStatus === 'assumpte_propi' && day.requestStatus === 'aprovat')
+      .sort((a, b) => parseISO(a.date).getTime() - parseISO(b.date).getTime()),
+    [daysData]
+  );
   const formatVacationDate = (date: string) => {
     const parsed = parseISO(date);
     return `${format(parsed, 'd')} de ${MONTH_NAMES_CA[parsed.getMonth()]}`;
   };
+  const formatAPHours = (hours: number | undefined) => formatDuration(hours || 0);
   const summaryItems = [
     {
       key: 'vacances',
@@ -183,11 +197,60 @@ export function StatusSummary({ config, daysData, variant = 'default' }: StatusS
       </DialogContent>
     </Dialog>
   );
+  const apDialog = (
+    <Dialog open={apDialogOpen} onOpenChange={setApDialogOpen}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Assumptes propis</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-5">
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold">Dies per aprovar</h3>
+            {pendingAPDaysList.length > 0 ? (
+              <ul className="space-y-2">
+                {pendingAPDaysList.map((day) => (
+                  <li
+                    key={day.date}
+                    className="flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm"
+                  >
+                    <span>{formatVacationDate(day.date)} · {formatAPHours(day.apHours)}</span>
+                    <span className="text-xs text-muted-foreground">Pendent</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">No hi ha dies pendents d'aprovació.</p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold">Dies aprovats</h3>
+            {approvedAPDaysList.length > 0 ? (
+              <ul className="space-y-2">
+                {approvedAPDaysList.map((day) => (
+                  <li
+                    key={day.date}
+                    className="flex items-center justify-between gap-3 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm"
+                  >
+                    <span>{formatVacationDate(day.date)} · {formatAPHours(day.apHours)}</span>
+                    <span className="text-xs text-muted-foreground">Aprovat</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">Encara no hi ha dies aprovats.</p>
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
 
   if (variant === 'compact') {
     return (
       <>
         {vacationDialog}
+        {apDialog}
         <div className="flex flex-wrap items-center gap-3">
           {summaryItems.map((item) => {
             const Icon = item.icon;
@@ -217,6 +280,18 @@ export function StatusSummary({ config, daysData, variant = 'default' }: StatusS
                 </button>
               );
             }
+            if (item.key === 'ap') {
+              return (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={() => setApDialogOpen(true)}
+                  className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  {content}
+                </button>
+              );
+            }
             return (
               <div key={item.key}>
                 {content}
@@ -231,6 +306,7 @@ export function StatusSummary({ config, daysData, variant = 'default' }: StatusS
   return (
     <>
       {vacationDialog}
+      {apDialog}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         {summaryItems.map((item) => {
           const Icon = item.icon;
@@ -262,6 +338,18 @@ export function StatusSummary({ config, daysData, variant = 'default' }: StatusS
                 key={item.key}
                 type="button"
                 onClick={() => setVacationDialogOpen(true)}
+                className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                {content}
+              </button>
+            );
+          }
+          if (item.key === 'ap') {
+            return (
+              <button
+                key={item.key}
+                type="button"
+                onClick={() => setApDialogOpen(true)}
                 className="text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               >
                 {content}


### PR DESCRIPTION
### Motivation
- Display the AP (Assumptes Propis) hours next to the date on the same line in the dialog lists instead of below it, per UI request.
- Provide a dedicated dialog and controls so AP items can be inspected from both `compact` and default summary variants.

### Description
- Added state `apDialogOpen` and new memoized lists `pendingAPDaysList` and `approvedAPDaysList` to compute AP days from `daysData`.
- Introduced `formatAPHours` helper and updated the AP dialog markup so each list item shows `formatVacationDate(day.date) · formatAPHours(day.apHours)` on a single line.
- Added the `apDialog` component and wired the AP summary item buttons in both `compact` and default layouts to open the dialog.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b0ea8fc083279b4fff88235a5811)