### PR TITLE
Add 'Falta aprovar' badge for pending absence requests in weekly summary

### DIFF
--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -14,7 +14,7 @@ import {
   formatHoursMinutes
 } from '@/lib/timeCalculations';
 import { DAY_NAMES_CA, MONTH_NAMES_CA } from '@/lib/constants';
-import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check, MoreHorizontal } from 'lucide-react';
+import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check, MoreHorizontal, AlertTriangle } from 'lucide-react';
 
 interface WeeklySummaryDialogProps {
   weekStart: Date | null;
@@ -165,6 +165,10 @@ export function WeeklySummaryDialog({
             const statusCardClass = getStatusCardClass(dayData, holiday, worked, theoretical);
             const schedule = getScheduleDisplay(dayData);
             const showStatusBadge = statusLabel !== 'Laboral';
+            const needsApproval = !holiday
+              && dayData
+              && ['vacances', 'assumpte_propi', 'flexibilitat', 'altres'].includes(dayData.dayStatus)
+              && dayData.requestStatus === 'pendent';
             
             return (
               <div
@@ -186,6 +190,12 @@ export function WeeklySummaryDialog({
                         <Badge variant="outline" className="text-xs flex items-center gap-1">
                           {StatusIcon && <StatusIcon className="w-3 h-3" />}
                           {statusLabel}
+                        </Badge>
+                      )}
+                      {needsApproval && (
+                        <Badge variant="destructive" className="text-xs flex items-center gap-1">
+                          <AlertTriangle className="w-3 h-3" />
+                          Falta aprovar
                         </Badge>
                       )}
                       {dayData?.requestStatus === 'aprovat' && (


### PR DESCRIPTION
### Motivation
- Visually indicate in the weekly summary when a day has a pending request for `vacances`, `assumpte_propi` (AP), `flexibilitat` (FX) or `altres` so users can quickly spot items that still need approval.

### Description
- Import `AlertTriangle` from `lucide-react`, compute a `needsApproval` flag for days with those `dayStatus` values and `requestStatus === 'pendent'`, and render a destructive `Badge` with the attention icon and the text "Falta aprovar" in `src/components/Calendar/WeeklySummaryDialog.tsx`; the existing approved badge remains unchanged.

### Testing
- No automated tests were run because `npm install` failed due to a 403 from the registry, so `npm test` could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973c7e86c848327bed7ed9b8c62422d)