### PR TITLE
Add GitHub Pages preview workflow for PRs

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,44 @@
+name: Preview Vite on GitHub Pages (PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages-preview-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm install
+      - run: npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true


### PR DESCRIPTION
### Motivation
- Provide deploy previews for pull requests so contributors and reviewers can see the built Vite app as a GitHub Pages preview before merging.

### Description
- Add ` .github/workflows/preview.yml` which triggers on `pull_request` (opened, synchronize, reopened), runs `npm install` and `npm run build`, uploads the `dist` artifact, and uses `actions/deploy-pages@v4` with `preview: true`, plus appropriate `permissions` and a `concurrency` group.

### Testing
- No automated tests were run for this change; the workflow is a CI config change and will execute on PR events to produce preview URLs if successful.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e93901588327b63808459ec06519)