### PR TITLE
Add GitHub Pages PR preview workflow and document how to access previews

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,44 @@
+name: Preview Vite on GitHub Pages (PR)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages-preview-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm install
+      - run: npm run build
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4
+        with:
+          preview: true

--- a/README.md
+++ b/README.md
@@ -71,6 +71,23 @@ npm run preview   # previsualitza el build localment
 
 ---
 
+## 🔎 Com provar un PR a GitHub (preview abans del merge)
+
+Si obres un **Pull Request**, hi ha un workflow que genera una **preview de GitHub Pages** per comprovar els canvis sense fer merge.
+
+### Passos ràpids
+1. Obre o actualitza el PR.
+2. Ves a la pestanya **Actions** del repositori.
+3. Obre el workflow **“Preview Vite on GitHub Pages (PR)”**.
+4. A l’execució del job **deploy**, trobaràs un enllaç **“View deployment”** amb la URL de la preview.
+
+### Què pots fer per provar-ho ràpid
+- Fes un canvi petit (p. ex. en un text de la UI).
+- Obre un PR amb aquest canvi.
+- Espera que el workflow acabi i obre la URL de preview.
+
+---
+
 ## 🔐 On es guarden les dades?
 
 L’aplicació **guarda la informació al navegador** (sense backend).  


### PR DESCRIPTION
### Motivation
- Provide deploy previews for pull requests so reviewers and contributors can inspect the built Vite app before merging.
- Make it easy for contributors to know how to trigger and access the preview deployment from the repository UI.

### Description
- Add ` .github/workflows/preview.yml` which runs on `pull_request` (opened, `synchronize`, `reopened`) and builds the app using `actions/setup-node@v4`, `npm install`, and `npm run build`.
- The workflow uploads the `dist` output with `actions/upload-pages-artifact@v3` and deploys a preview using `actions/deploy-pages@v4` with `preview: true` and the required `permissions` for `pages` and `id-token`.
- Update `README.md` with a new Catalan section explaining how to access the PR preview via the **Actions** tab, how to find the "View deployment" link, and quick steps to test the preview.

### Testing
- No automated tests were run for these changes because this is a CI configuration and documentation update. 
- The workflow is configured to execute on PR events and will produce preview URLs when triggered by a PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973e93901588327b63808459ec06519)