### PR TITLE
Make header logo red

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -21,8 +21,8 @@ export function Header({ config, daysData, onOpenSettings }: HeaderProps) {
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:gap-6">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-primary rounded-lg">
-                <Clock className="w-6 h-6 text-primary-foreground" />
+              <div className="p-2 bg-red-500 rounded-lg">
+                <Clock className="w-6 h-6 text-white" />
               </div>
               <div>
                 <h1 className="text-xl font-bold text-foreground">Control horari</h1>


### PR DESCRIPTION
### Motivation
- Provide a visible preview change by making the header/app logo use a red background and white icon to confirm styling updates.

### Description
- Update `src/components/Header.tsx` to replace the logo container classes from `bg-primary` / `text-primary-foreground` to `bg-red-500` / `text-white` so the header logo appears red with a white icon.

### Testing
- Attempted to install dependencies with `npm install`, but the install failed with a 403 from the npm registry, so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973ee4a9b888327b0c64db77a4d6411)