### PR TITLE
Add onboarding flow and step gating to initial Settings dialog

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -15,22 +15,58 @@ import { exportAllData, importAllData, resetAllData, type ExportData } from '@/l
 import { safeValidateExportData, MAX_IMPORT_FILE_SIZE } from '@/lib/validation';
 import { toast } from 'sonner';
 
+const ONBOARDING_TABS = {
+  1: 'personal',
+  2: 'schedule',
+  3: 'holidays',
+} as const;
+
+const SETTINGS_TABS = [
+  { value: 'personal', label: 'Personal' },
+  { value: 'schedule', label: 'Horari' },
+  { value: 'holidays', label: 'Festius' },
+  { value: 'data', label: 'Dades' },
+  { value: 'authorship', label: 'Autoria' },
+] as const;
+
 interface SettingsDialogProps {
   open: boolean;
   config: UserConfig;
   onClose: () => void;
   onSave: (config: UserConfig) => void;
   onDataReset?: () => void;
+  onboardingStep?: number;
+  onOnboardingStepChange?: (step: number) => void;
 }
 
-export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: SettingsDialogProps) {
+export function SettingsDialog({
+  open,
+  config,
+  onClose,
+  onSave,
+  onDataReset,
+  onboardingStep = 0,
+  onOnboardingStepChange,
+}: SettingsDialogProps) {
   const [localConfig, setLocalConfig] = useState<UserConfig>(config);
   const [newHoliday, setNewHoliday] = useState('');
+  const [activeTab, setActiveTab] = useState<'personal' | 'schedule' | 'holidays' | 'data' | 'authorship'>('personal');
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const isOnboarding = onboardingStep > 0;
+  const visibleTabs = isOnboarding ? SETTINGS_TABS.slice(0, onboardingStep) : SETTINGS_TABS;
 
   useEffect(() => {
     setLocalConfig(config);
   }, [config]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (isOnboarding) {
+      setActiveTab(ONBOARDING_TABS[onboardingStep] ?? 'personal');
+      return;
+    }
+    setActiveTab('personal');
+  }, [open, isOnboarding, onboardingStep]);
 
   const getYearBounds = (year: number) => ({
     start: new Date(year, 0, 1),
@@ -103,6 +139,13 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
 
   const handleSave = () => {
     onSave({ ...localConfig, schedulePeriods: sortedSchedulePeriods });
+    if (isOnboarding) {
+      if (onboardingStep < 3) {
+        onOnboardingStepChange?.(onboardingStep + 1);
+        return;
+      }
+      onOnboardingStepChange?.(0);
+    }
     onClose();
   };
 
@@ -268,13 +311,16 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
           <DialogTitle className="text-xl">Configuració</DialogTitle>
         </DialogHeader>
 
-        <Tabs defaultValue="personal" className="w-full">
-          <TabsList className="grid w-full grid-cols-5">
-            <TabsTrigger value="personal">Personal</TabsTrigger>
-            <TabsTrigger value="schedule">Horari</TabsTrigger>
-            <TabsTrigger value="holidays">Festius</TabsTrigger>
-            <TabsTrigger value="data">Dades</TabsTrigger>
-            <TabsTrigger value="authorship">Autoria</TabsTrigger>
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <TabsList
+            className="grid w-full"
+            style={{ gridTemplateColumns: `repeat(${visibleTabs.length}, minmax(0, 1fr))` }}
+          >
+            {visibleTabs.map(tab => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
           </TabsList>
 
           <TabsContent value="personal" className="space-y-4 pt-4">
@@ -332,7 +378,8 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
 
           </TabsContent>
 
-          <TabsContent value="schedule" className="space-y-4 pt-4">
+          {(!isOnboarding || onboardingStep >= 2) && (
+            <TabsContent value="schedule" className="space-y-4 pt-4">
             <div className="mb-6 flex items-center gap-3">
               <Label htmlFor="defaultStart" className="min-w-[200px]">
                 Hora d'inici per defecte
@@ -444,9 +491,11 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 ))}
               </div>
             </div>
-          </TabsContent>
+            </TabsContent>
+          )}
 
-          <TabsContent value="holidays" className="space-y-4 pt-4">
+          {(!isOnboarding || onboardingStep >= 3) && (
+            <TabsContent value="holidays" className="space-y-4 pt-4">
             <div className="flex gap-2">
               <Input
                 type="date"
@@ -480,9 +529,11 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 );
               })}
             </div>
-          </TabsContent>
+            </TabsContent>
+          )}
 
-          <TabsContent value="data" className="space-y-6 pt-4">
+          {!isOnboarding && (
+            <TabsContent value="data" className="space-y-6 pt-4">
             {/* Privacy Notice */}
             <div className="flex gap-3 p-3 bg-muted/50 rounded-lg border">
               <Info className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
@@ -562,9 +613,11 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 </AlertDialogContent>
               </AlertDialog>
             </div>
-          </TabsContent>
+            </TabsContent>
+          )}
 
-          <TabsContent value="authorship" className="space-y-6 pt-4">
+          {!isOnboarding && (
+            <TabsContent value="authorship" className="space-y-6 pt-4">
             <div className="space-y-1">
               <h3 className="text-lg font-semibold">Detalls del projecte</h3>
             </div>
@@ -592,7 +645,8 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 <dd className="font-medium text-right">{APP_INFO.version}</dd>
               </div>
             </dl>
-          </TabsContent>
+            </TabsContent>
+          )}
         </Tabs>
 
         <DialogFooter>
@@ -600,7 +654,7 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
             Cancel·lar
           </Button>
           <Button onClick={handleSave}>
-            Desar canvis
+            {isOnboarding ? (onboardingStep < 3 ? 'Desar i continuar' : 'Desar i finalitzar') : 'Desar canvis'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -5,6 +5,40 @@ import { parseISO } from 'date-fns';
 
 const USER_CONFIG_KEY = 'control-horari-config';
 const DAYS_DATA_KEY = 'control-horari-days';
+const ONBOARDING_STEP_KEY = 'control-horari-onboarding-step';
+
+export function hasStoredUserConfig(): boolean {
+  try {
+    return localStorage.getItem(USER_CONFIG_KEY) !== null;
+  } catch (error) {
+    console.error('Error checking user config:', error);
+    return false;
+  }
+}
+
+export function getOnboardingStep(): number {
+  try {
+    const stored = localStorage.getItem(ONBOARDING_STEP_KEY);
+    if (!stored) return 0;
+    const parsed = Number(stored);
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch (error) {
+    console.error('Error loading onboarding step:', error);
+    return 0;
+  }
+}
+
+export function saveOnboardingStep(step: number): void {
+  try {
+    if (step <= 0) {
+      localStorage.removeItem(ONBOARDING_STEP_KEY);
+      return;
+    }
+    localStorage.setItem(ONBOARDING_STEP_KEY, String(step));
+  } catch (error) {
+    console.error('Error saving onboarding step:', error);
+  }
+}
 
 export function getUserConfig(): UserConfig {
   try {


### PR DESCRIPTION
### Motivation
- Provide a first-run onboarding so the app opens the Settings dialog automatically and guides users through the initial configuration. 
- Ensure the initial setup is persisted so the onboarding only appears when needed. 
- Expose only the first three settings tabs during onboarding and require the user to save each tab to reveal the next, simplifying first-time setup.

### Description
- Persist onboarding state in local storage and add helpers `getOnboardingStep`, `saveOnboardingStep`, and `hasStoredUserConfig` in `src/lib/storage.ts`.
- Extend `SettingsDialog` with `onboardingStep` and `onOnboardingStepChange` props, add internal `activeTab` handling, and compute a `visibleTabs` list so only the allowed tabs are shown during onboarding, and change the save flow to advance the onboarding step (labels show `Desar i continuar` / `Desar i finalitzar`).
- Gate rendering of the `schedule` and `holidays` tab content behind the onboarding step (first three tabs appear incrementally) and hide `data`/`authorship` until onboarding finishes.
- Auto-open the Settings dialog on first run and manage onboarding state from `src/pages/Index.tsx`, wiring `handleOnboardingStepChange` to persist progress and close the dialog when onboarding completes.
- Files changed: `src/lib/storage.ts`, `src/components/Settings/SettingsDialog.tsx`, and `src/pages/Index.tsx`.

### Testing
- Attempted to install dependencies with `npm install` to run the app/tests but the install failed with a registry `403` error, so no automated test suite was executed. 
- No unit or integration tests were run due to the dependency installation failure. 
- Basic code edits were applied and source inspected locally; runtime verification should be done after dependencies can be installed (open the app and confirm settings auto-opens on first run and that saving advances tabs).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f0f35ad08327a8dac642b7b1a580)