### PR TITLE
Block calendar until initial onboarding (first 3 tabs) is completed

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -15,22 +15,58 @@ import { exportAllData, importAllData, resetAllData, type ExportData } from '@/l
 import { safeValidateExportData, MAX_IMPORT_FILE_SIZE } from '@/lib/validation';
 import { toast } from 'sonner';
 
+const ONBOARDING_TABS = {
+  1: 'personal',
+  2: 'schedule',
+  3: 'holidays',
+} as const;
+
+const SETTINGS_TABS = [
+  { value: 'personal', label: 'Personal' },
+  { value: 'schedule', label: 'Horari' },
+  { value: 'holidays', label: 'Festius' },
+  { value: 'data', label: 'Dades' },
+  { value: 'authorship', label: 'Autoria' },
+] as const;
+
 interface SettingsDialogProps {
   open: boolean;
   config: UserConfig;
   onClose: () => void;
   onSave: (config: UserConfig) => void;
   onDataReset?: () => void;
+  onboardingStep?: number;
+  onOnboardingStepChange?: (step: number) => void;
 }
 
-export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: SettingsDialogProps) {
+export function SettingsDialog({
+  open,
+  config,
+  onClose,
+  onSave,
+  onDataReset,
+  onboardingStep = 0,
+  onOnboardingStepChange,
+}: SettingsDialogProps) {
   const [localConfig, setLocalConfig] = useState<UserConfig>(config);
   const [newHoliday, setNewHoliday] = useState('');
+  const [activeTab, setActiveTab] = useState<'personal' | 'schedule' | 'holidays' | 'data' | 'authorship'>('personal');
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const isOnboarding = onboardingStep > 0;
+  const visibleTabs = isOnboarding ? SETTINGS_TABS.slice(0, onboardingStep) : SETTINGS_TABS;
 
   useEffect(() => {
     setLocalConfig(config);
   }, [config]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (isOnboarding) {
+      setActiveTab(ONBOARDING_TABS[onboardingStep] ?? 'personal');
+      return;
+    }
+    setActiveTab('personal');
+  }, [open, isOnboarding, onboardingStep]);
 
   const getYearBounds = (year: number) => ({
     start: new Date(year, 0, 1),
@@ -103,6 +139,13 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
 
   const handleSave = () => {
     onSave({ ...localConfig, schedulePeriods: sortedSchedulePeriods });
+    if (isOnboarding) {
+      if (onboardingStep < 3) {
+        onOnboardingStepChange?.(onboardingStep + 1);
+        return;
+      }
+      onOnboardingStepChange?.(0);
+    }
     onClose();
   };
 
@@ -261,20 +304,30 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
     setTimeout(() => window.location.reload(), 1000);
   };
 
+  const handleDialogOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && isOnboarding) {
+      return;
+    }
+    onClose();
+  };
+
   return (
-    <Dialog open={open} onOpenChange={onClose}>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
       <DialogContent className="sm:max-w-2xl max-h-[85vh] overflow-y-auto">
         <DialogHeader>
           <DialogTitle className="text-xl">Configuració</DialogTitle>
         </DialogHeader>
 
-        <Tabs defaultValue="personal" className="w-full">
-          <TabsList className="grid w-full grid-cols-5">
-            <TabsTrigger value="personal">Personal</TabsTrigger>
-            <TabsTrigger value="schedule">Horari</TabsTrigger>
-            <TabsTrigger value="holidays">Festius</TabsTrigger>
-            <TabsTrigger value="data">Dades</TabsTrigger>
-            <TabsTrigger value="authorship">Autoria</TabsTrigger>
+        <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
+          <TabsList
+            className="grid w-full"
+            style={{ gridTemplateColumns: `repeat(${visibleTabs.length}, minmax(0, 1fr))` }}
+          >
+            {visibleTabs.map(tab => (
+              <TabsTrigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </TabsTrigger>
+            ))}
           </TabsList>
 
           <TabsContent value="personal" className="space-y-4 pt-4">
@@ -332,7 +385,8 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
 
           </TabsContent>
 
-          <TabsContent value="schedule" className="space-y-4 pt-4">
+          {(!isOnboarding || onboardingStep >= 2) && (
+            <TabsContent value="schedule" className="space-y-4 pt-4">
             <div className="mb-6 flex items-center gap-3">
               <Label htmlFor="defaultStart" className="min-w-[200px]">
                 Hora d'inici per defecte
@@ -444,9 +498,11 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 ))}
               </div>
             </div>
-          </TabsContent>
+            </TabsContent>
+          )}
 
-          <TabsContent value="holidays" className="space-y-4 pt-4">
+          {(!isOnboarding || onboardingStep >= 3) && (
+            <TabsContent value="holidays" className="space-y-4 pt-4">
             <div className="flex gap-2">
               <Input
                 type="date"
@@ -480,9 +536,11 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 );
               })}
             </div>
-          </TabsContent>
+            </TabsContent>
+          )}
 
-          <TabsContent value="data" className="space-y-6 pt-4">
+          {!isOnboarding && (
+            <TabsContent value="data" className="space-y-6 pt-4">
             {/* Privacy Notice */}
             <div className="flex gap-3 p-3 bg-muted/50 rounded-lg border">
               <Info className="w-5 h-5 text-muted-foreground flex-shrink-0 mt-0.5" />
@@ -562,9 +620,11 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 </AlertDialogContent>
               </AlertDialog>
             </div>
-          </TabsContent>
+            </TabsContent>
+          )}
 
-          <TabsContent value="authorship" className="space-y-6 pt-4">
+          {!isOnboarding && (
+            <TabsContent value="authorship" className="space-y-6 pt-4">
             <div className="space-y-1">
               <h3 className="text-lg font-semibold">Detalls del projecte</h3>
             </div>
@@ -592,15 +652,18 @@ export function SettingsDialog({ open, config, onClose, onSave, onDataReset }: S
                 <dd className="font-medium text-right">{APP_INFO.version}</dd>
               </div>
             </dl>
-          </TabsContent>
+            </TabsContent>
+          )}
         </Tabs>
 
         <DialogFooter>
-          <Button variant="outline" onClick={onClose}>
-            Cancel·lar
-          </Button>
+          {!isOnboarding && (
+            <Button variant="outline" onClick={onClose}>
+              Cancel·lar
+            </Button>
+          )}
           <Button onClick={handleSave}>
-            Desar canvis
+            {isOnboarding ? (onboardingStep < 3 ? 'Desar i continuar' : 'Desar i finalitzar') : 'Desar canvis'}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -5,6 +5,40 @@ import { parseISO } from 'date-fns';
 
 const USER_CONFIG_KEY = 'control-horari-config';
 const DAYS_DATA_KEY = 'control-horari-days';
+const ONBOARDING_STEP_KEY = 'control-horari-onboarding-step';
+
+export function hasStoredUserConfig(): boolean {
+  try {
+    return localStorage.getItem(USER_CONFIG_KEY) !== null;
+  } catch (error) {
+    console.error('Error checking user config:', error);
+    return false;
+  }
+}
+
+export function getOnboardingStep(): number {
+  try {
+    const stored = localStorage.getItem(ONBOARDING_STEP_KEY);
+    if (!stored) return 0;
+    const parsed = Number(stored);
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch (error) {
+    console.error('Error loading onboarding step:', error);
+    return 0;
+  }
+}
+
+export function saveOnboardingStep(step: number): void {
+  try {
+    if (step <= 0) {
+      localStorage.removeItem(ONBOARDING_STEP_KEY);
+      return;
+    }
+    localStorage.setItem(ONBOARDING_STEP_KEY, String(step));
+  } catch (error) {
+    console.error('Error saving onboarding step:', error);
+  }
+}
 
 export function getUserConfig(): UserConfig {
   try {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,13 +1,51 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Header } from '@/components/Header';
 import { CalendarGrid } from '@/components/Calendar/CalendarGrid';
 import { SettingsDialog } from '@/components/Settings/SettingsDialog';
 import { useTimeTracking } from '@/hooks/useTimeTracking';
 import { Skeleton } from '@/components/ui/skeleton';
+import { getOnboardingStep, hasStoredUserConfig, saveOnboardingStep } from '@/lib/storage';
 
 const Index = () => {
   const { config, daysData, isLoading, updateConfig, updateDayData } = useTimeTracking();
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const [onboardingStep, setOnboardingStep] = useState(0);
+  const isOnboarding = onboardingStep > 0;
+
+  useEffect(() => {
+    if (isLoading) return;
+    const storedStep = getOnboardingStep();
+    let nextStep = storedStep;
+    if (!hasStoredUserConfig() && storedStep === 0) {
+      nextStep = 1;
+      saveOnboardingStep(nextStep);
+    }
+    setOnboardingStep(nextStep);
+    if (nextStep > 0) {
+      setSettingsOpen(true);
+    }
+  }, [isLoading]);
+
+  useEffect(() => {
+    if (onboardingStep > 0) {
+      setSettingsOpen(true);
+    }
+  }, [onboardingStep]);
+
+  const handleOnboardingStepChange = (step: number) => {
+    setOnboardingStep(step);
+    saveOnboardingStep(step);
+    if (step === 0) {
+      setSettingsOpen(false);
+    }
+  };
+
+  const handleCloseSettings = () => {
+    if (isOnboarding) {
+      return;
+    }
+    setSettingsOpen(false);
+  };
 
   if (isLoading) {
     return (
@@ -29,19 +67,30 @@ const Index = () => {
       />
       
       <main className="container mx-auto px-4 py-6 space-y-6">
-        <CalendarGrid
-          daysData={daysData}
-          config={config}
-          onDayUpdate={updateDayData}
-        />
+        {isOnboarding ? (
+          <div className="rounded-lg border border-dashed border-muted-foreground/40 bg-muted/30 p-8 text-center text-muted-foreground">
+            <h2 className="text-lg font-semibold text-foreground">Completa la configuració inicial</h2>
+            <p className="mt-2 text-sm">
+              Revisa i desa les pestanyes Personal, Horari i Festius per començar a fer servir el calendari.
+            </p>
+          </div>
+        ) : (
+          <CalendarGrid
+            daysData={daysData}
+            config={config}
+            onDayUpdate={updateDayData}
+          />
+        )}
         
       </main>
 
       <SettingsDialog
         open={settingsOpen}
         config={config}
-        onClose={() => setSettingsOpen(false)}
+        onClose={handleCloseSettings}
         onSave={updateConfig}
+        onboardingStep={onboardingStep}
+        onOnboardingStepChange={handleOnboardingStepChange}
       />
     </div>
   );


### PR DESCRIPTION
### Motivation
- Ensure first-time users complete the minimal configuration (Personal, Schedule, Holidays) before interacting with the calendar UI. 
- Persist onboarding progress so the app can resume and close onboarding when finished. 
- Prevent users from bypassing onboarding by closing the settings dialog early.

### Description
- Add persistent onboarding helpers in `src/lib/storage.ts`: `getOnboardingStep`, `saveOnboardingStep`, and `hasStoredUserConfig` to read/write the onboarding step in localStorage. 
- Update `SettingsDialog` (`src/components/Settings/SettingsDialog.tsx`) to track `activeTab`, compute `visibleTabs` during onboarding, hide non-essential tabs, prevent closing the dialog while onboarding, hide the cancel action, and advance/reset onboarding via `onOnboardingStepChange`. 
- Update page entry point (`src/pages/Index.tsx`) to load and save onboarding state, auto-open settings on first run, block rendering of `CalendarGrid` while onboarding with a centered prompt, and prevent closing settings if onboarding is active.

### Testing
- Attempted to install dependencies with `npm install`, but it failed due to a `403 Forbidden` fetching `@testing-library/jest-dom`, so no automated tests or app run was executed. 
- No unit or integration tests were run because dependency installation failed. 
- Local static inspection and small runtime checks (state/prop wiring) were performed in the source files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f0f35ad08327a8dac642b7b1a580)