### PR TITLE
Block out-of-year calendar days from interaction and weekly summaries

### DIFF
--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -9,11 +9,12 @@ interface CalendarDayProps {
   dayData: DayData | null;
   config: UserConfig;
   isCurrentMonth: boolean;
+  isInCalendarYear: boolean;
   isToday: boolean;
   onClick: () => void;
 }
 
-export function CalendarDay({ date, dayData, config, isCurrentMonth, isToday, onClick }: CalendarDayProps) {
+export function CalendarDay({ date, dayData, config, isCurrentMonth, isInCalendarYear, isToday, onClick }: CalendarDayProps) {
   const weekend = isWeekend(date);
   const holiday = isHoliday(date, config.holidays);
   const dateStr = format(date, 'yyyy-MM-dd');
@@ -64,7 +65,7 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isToday, on
     return 'bg-[hsl(var(--status-deficit))] text-[hsl(var(--status-deficit-foreground))]';
   };
 
-  const dayType = getDayTypeForDate(date, config);
+  const dayType = isInCalendarYear ? getDayTypeForDate(date, config) : null;
   const DayIcon = dayType === 'teletreball' ? Home : Building2;
 
   const getStatusIcon = () => {
@@ -130,14 +131,14 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isToday, on
   return (
     <button
       onClick={onClick}
-      disabled={weekend}
+      disabled={weekend || !isInCalendarYear}
       className={cn(
         'relative p-2 h-20 w-full rounded-lg transition-all duration-200 border',
         'hover:shadow-md hover:scale-[1.02] focus:outline-none focus:ring-2 focus:ring-primary',
         getStatusColor(),
         !isCurrentMonth && 'opacity-40',
         isToday && 'ring-2 ring-primary ring-offset-2',
-        weekend && 'cursor-default hover:scale-100 hover:shadow-none'
+        (weekend || !isInCalendarYear) && 'cursor-default hover:scale-100 hover:shadow-none'
       )}
     >
       <div className="flex flex-col h-full">
@@ -145,12 +146,12 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isToday, on
           <span className={cn('text-sm font-semibold', isToday && 'text-primary')}>
             {format(date, 'd')}
           </span>
-          {!weekend && !holiday && (
+          {!weekend && !holiday && isInCalendarYear && (
             <DayIcon className="w-3.5 h-3.5 opacity-70" />
           )}
         </div>
         
-        {!weekend && (
+        {!weekend && isInCalendarYear && (
           <div className="flex-1 flex flex-col justify-end">
             {shifts.length > 0 && (
               <div className="text-xs opacity-80 space-y-0.5">

--- a/src/components/Calendar/CalendarGrid.tsx
+++ b/src/components/Calendar/CalendarGrid.tsx
@@ -110,13 +110,15 @@ export function CalendarGrid({ daysData, config, onDayUpdate }: CalendarGridProp
             <div key={weekIndex} className="grid grid-cols-8 gap-2">
               {week.map((day) => {
                 const dateStr = format(day, 'yyyy-MM-dd');
+                const isInCalendarYear = day.getFullYear() === calendarYear;
                 return (
                   <CalendarDay
                     key={dateStr}
                     date={day}
-                    dayData={daysData[dateStr] || null}
+                    dayData={isInCalendarYear ? daysData[dateStr] || null : null}
                     config={config}
                     isCurrentMonth={isSameMonth(day, currentDate)}
+                    isInCalendarYear={isInCalendarYear}
                     isToday={isToday(day)}
                     onClick={() => setSelectedDate(day)}
                   />

--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -33,10 +33,14 @@ export function WeeklySummaryDialog({
 }: WeeklySummaryDialogProps) {
   if (!weekStart || !weekEnd) return null;
 
-  const days = eachDayOfInterval({ start: weekStart, end: weekEnd });
+  const days = eachDayOfInterval({ start: weekStart, end: weekEnd }).filter(
+    (day) => day.getFullYear() === config.calendarYear
+  );
   const hasAnyData = days.some((day) => !!daysData[format(day, 'yyyy-MM-dd')]);
   if (!hasAnyData) return null;
-  const weekNumber = getWeek(weekStart, { weekStartsOn: 1 });
+  const displayStart = days[0] ?? weekStart;
+  const displayEnd = days[days.length - 1] ?? weekEnd;
+  const weekNumber = getWeek(displayStart, { weekStartsOn: 1 });
 
   const getDayName = (date: Date) => {
     const dayIndex = date.getDay();
@@ -132,7 +136,7 @@ export function WeeklySummaryDialog({
               Resum Setmana {weekNumber}
             </DialogTitle>
             <p className="text-base font-medium text-muted-foreground">
-              {format(weekStart, 'd')} - {format(weekEnd, 'd')} de {MONTH_NAMES_CA[weekStart.getMonth()]}
+              {format(displayStart, 'd')} - {format(displayEnd, 'd')} de {MONTH_NAMES_CA[displayStart.getMonth()]}
             </p>
           </div>
         </DialogHeader>

--- a/src/components/Calendar/WeeklySummaryIcon.tsx
+++ b/src/components/Calendar/WeeklySummaryIcon.tsx
@@ -13,7 +13,9 @@ interface WeeklySummaryIconProps {
 }
 
 export function WeeklySummaryIcon({ weekStart, weekEnd, daysData, config, onClick }: WeeklySummaryIconProps) {
-  const days = eachDayOfInterval({ start: weekStart, end: weekEnd });
+  const days = eachDayOfInterval({ start: weekStart, end: weekEnd }).filter(
+    (day) => day.getFullYear() === config.calendarYear
+  );
   const hasAnyData = days.some((day) => !!daysData[format(day, 'yyyy-MM-dd')]);
 
   if (!hasAnyData) {


### PR DESCRIPTION
### Motivation
- Prevent days that belong to a different year from being interactive or counted in weekly computations so the calendar only operates within the configured `calendarYear`.
- Ensure end-of-December spillover days (e.g. 29/30/31) and days from the following year that appear in the grid are treated as inaccessible and excluded from totals.
- Provide consistent weekly icons/dialogs that reflect only the in-year date range for clarity in weekly summaries.

### Description
- Added an `isInCalendarYear` prop to `CalendarDay` and disabled interaction and detail display for days where `day.getFullYear() !== config.calendarYear` in `src/components/Calendar/CalendarDay.tsx`.
- Compute `isInCalendarYear` in `src/components/Calendar/CalendarGrid.tsx` and only pass `dayData` to `CalendarDay` when the date is inside the configured year.
- Filter the day range used by the weekly summary icon in `src/components/Calendar/WeeklySummaryIcon.tsx` to only include days with `day.getFullYear() === config.calendarYear` so icons ignore out-of-year dates.
- Filter the dialog day list in `src/components/Calendar/WeeklySummaryDialog.tsx` for `config.calendarYear` and adjust the week header to use the first/last in-year day as `displayStart`/`displayEnd`.

### Testing
- Attempted to run dependency install with `npm install`, but the command failed due to a registry error (`403 Forbidden` for `@testing-library/jest-dom`), so automated tests were not executed.
- No automated test runs completed because the install failure prevented running the test/build pipeline.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973f9e99a348327a5092dc196f8b06f)