### PR TITLE
Set default schedule to Estiu and prevent editing 01/01 start date

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -175,9 +175,12 @@ export function SettingsDialog({
       if (periodIndex === -1) return prev;
 
       const updatedPeriod = { ...prev.schedulePeriods[periodIndex] };
+      const { startString: yearStart } = getYearBounds(prev.calendarYear);
 
       if (field === 'scheduleType') {
         updatedPeriod.scheduleType = value as ScheduleType;
+      } else if (field === 'startDate' && updatedPeriod.startDate === yearStart) {
+        return prev;
       } else {
         updatedPeriod[field] = value;
       }
@@ -457,53 +460,58 @@ export function SettingsDialog({
               )}
 
               <div className="space-y-2">
-                {sortedSchedulePeriods.map((period) => (
-                  <div key={period.id} className="flex items-center gap-2 p-3 bg-muted rounded-lg flex-wrap">
-                    <Select
-                      value={period.scheduleType}
-                      onValueChange={(v) => updateSchedulePeriod(period.id, 'scheduleType', v)}
-                    >
-                      <SelectTrigger className="w-24">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="hivern">Hivern</SelectItem>
-                        <SelectItem value="estiu">Estiu</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <span className="text-sm text-muted-foreground">de</span>
-                    <Input
-                      type="date"
-                      className="w-36"
-                      value={period.startDate}
-                      onChange={(e) => updateSchedulePeriod(period.id, 'startDate', e.target.value)}
-                      min={yearBounds.startString}
-                      max={yearBounds.endString}
-                    />
-                    <span className="text-sm text-muted-foreground">a</span>
-                    <Input
-                      type="date"
-                      className="w-36"
-                      value={period.endDate}
-                      onChange={(e) => updateSchedulePeriod(period.id, 'endDate', e.target.value)}
-                      min={yearBounds.startString}
-                      max={yearBounds.endString}
-                    />
-                    <span className="text-muted-foreground text-sm ml-auto">
-                      ({SCHEDULE_HOURS[period.scheduleType]}h/dia)
-                    </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8"
-                      onClick={() => removeSchedulePeriod(period.id)}
-                      disabled={sortedSchedulePeriods.length <= 1}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
+                {sortedSchedulePeriods.map((period) => {
+                  const isYearStart = period.startDate === yearBounds.startString;
+                  return (
+                    <div key={period.id} className="flex items-center gap-2 p-3 bg-muted rounded-lg flex-wrap">
+                      <Select
+                        value={period.scheduleType}
+                        onValueChange={(v) => updateSchedulePeriod(period.id, 'scheduleType', v)}
+                      >
+                        <SelectTrigger className="w-24">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="hivern">Hivern</SelectItem>
+                          <SelectItem value="estiu">Estiu</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <span className="text-sm text-muted-foreground">de</span>
+                      <Input
+                        type="date"
+                        className="w-36"
+                        value={period.startDate}
+                        onChange={(e) => updateSchedulePeriod(period.id, 'startDate', e.target.value)}
+                        min={yearBounds.startString}
+                        max={yearBounds.endString}
+                        disabled={isYearStart}
+                        title={isYearStart ? 'El dia 01/01 no es pot editar.' : undefined}
+                      />
+                      <span className="text-sm text-muted-foreground">a</span>
+                      <Input
+                        type="date"
+                        className="w-36"
+                        value={period.endDate}
+                        onChange={(e) => updateSchedulePeriod(period.id, 'endDate', e.target.value)}
+                        min={yearBounds.startString}
+                        max={yearBounds.endString}
+                      />
+                      <span className="text-muted-foreground text-sm ml-auto">
+                        ({SCHEDULE_HOURS[period.scheduleType]}h/dia)
+                      </span>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                        onClick={() => removeSchedulePeriod(period.id)}
+                        disabled={sortedSchedulePeriods.length <= 1}
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  );
+                })}
               </div>
             </div>
             </TabsContent>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,7 +35,7 @@ export const DEFAULT_USER_CONFIG = {
       id: 'default-winter',
       startDate: `${DEFAULT_CALENDAR_YEAR}-01-01`,
       endDate: `${DEFAULT_CALENDAR_YEAR}-12-31`,
-      scheduleType: 'hivern' as const,
+      scheduleType: 'estiu' as const,
     },
   ],
   totalVacationDays: 25,


### PR DESCRIPTION
### Motivation
- The calendar should use the "Estiu" schedule by default for the initial period instead of "Hivern".
- The start date 01/01 must be immutable so users cannot accidentally change the calendar-year anchor.

### Description
- Changed the default schedule period in `src/lib/constants.ts` to use `scheduleType: 'estiu'` for the initial period.
- In `src/components/Settings/SettingsDialog.tsx` disabled the start-date input when the period `startDate` equals the year start and added a `title` explaining that `01/01` is not editable.
- Added a guard in `updateSchedulePeriod` to ignore attempts to update a period's `startDate` when that value is the year start, preventing programmatic changes as well.

### Testing
- Attempted to install dependencies with `npm install`, but the command failed due to a `403 Forbidden` from the npm registry so no runtime or automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fd9f778c8327a8689a70df81af60)