### PR TITLE
Amaga la paperera a la primera franja i afegeix proteccions de calendari

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -146,6 +146,10 @@ export function SettingsDialog({
   const yearBounds = getYearBounds(localConfig.calendarYear);
 
   const handleSave = () => {
+    if (!scheduleValidation.isValid) {
+      toast.error(`Falten ${scheduleValidation.missingDays} dies per definir`);
+      return;
+    }
     onSave({ ...localConfig, schedulePeriods: sortedSchedulePeriods });
     if (isOnboarding) {
       if (onboardingStep < 3) {
@@ -175,9 +179,12 @@ export function SettingsDialog({
       if (periodIndex === -1) return prev;
 
       const updatedPeriod = { ...prev.schedulePeriods[periodIndex] };
+      const { startString: yearStart } = getYearBounds(prev.calendarYear);
 
       if (field === 'scheduleType') {
         updatedPeriod.scheduleType = value as ScheduleType;
+      } else if (field === 'startDate' && updatedPeriod.startDate === yearStart) {
+        return prev;
       } else {
         updatedPeriod[field] = value;
       }
@@ -457,53 +464,61 @@ export function SettingsDialog({
               )}
 
               <div className="space-y-2">
-                {sortedSchedulePeriods.map((period) => (
-                  <div key={period.id} className="flex items-center gap-2 p-3 bg-muted rounded-lg flex-wrap">
-                    <Select
-                      value={period.scheduleType}
-                      onValueChange={(v) => updateSchedulePeriod(period.id, 'scheduleType', v)}
-                    >
-                      <SelectTrigger className="w-24">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="hivern">Hivern</SelectItem>
-                        <SelectItem value="estiu">Estiu</SelectItem>
-                      </SelectContent>
-                    </Select>
-                    <span className="text-sm text-muted-foreground">de</span>
-                    <Input
-                      type="date"
-                      className="w-36"
-                      value={period.startDate}
-                      onChange={(e) => updateSchedulePeriod(period.id, 'startDate', e.target.value)}
-                      min={yearBounds.startString}
-                      max={yearBounds.endString}
-                    />
-                    <span className="text-sm text-muted-foreground">a</span>
-                    <Input
-                      type="date"
-                      className="w-36"
-                      value={period.endDate}
-                      onChange={(e) => updateSchedulePeriod(period.id, 'endDate', e.target.value)}
-                      min={yearBounds.startString}
-                      max={yearBounds.endString}
-                    />
-                    <span className="text-muted-foreground text-sm ml-auto">
-                      ({SCHEDULE_HOURS[period.scheduleType]}h/dia)
-                    </span>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-8 w-8"
-                      onClick={() => removeSchedulePeriod(period.id)}
-                      disabled={sortedSchedulePeriods.length <= 1}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
-                  </div>
-                ))}
+                {sortedSchedulePeriods.map((period, index) => {
+                  const isYearStart = period.startDate === yearBounds.startString;
+                  const isFirstPeriod = index === 0;
+                  return (
+                    <div key={period.id} className="flex items-center gap-2 p-3 bg-muted rounded-lg flex-wrap">
+                      <Select
+                        value={period.scheduleType}
+                        onValueChange={(v) => updateSchedulePeriod(period.id, 'scheduleType', v)}
+                      >
+                        <SelectTrigger className="w-24">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="hivern">Hivern</SelectItem>
+                          <SelectItem value="estiu">Estiu</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <span className="text-sm text-muted-foreground">de</span>
+                      <Input
+                        type="date"
+                        className="w-36"
+                        value={period.startDate}
+                        onChange={(e) => updateSchedulePeriod(period.id, 'startDate', e.target.value)}
+                        min={yearBounds.startString}
+                        max={yearBounds.endString}
+                        disabled={isYearStart}
+                        title={isYearStart ? 'El dia 01/01 no es pot editar.' : undefined}
+                      />
+                      <span className="text-sm text-muted-foreground">a</span>
+                      <Input
+                        type="date"
+                        className="w-36"
+                        value={period.endDate}
+                        onChange={(e) => updateSchedulePeriod(period.id, 'endDate', e.target.value)}
+                        min={yearBounds.startString}
+                        max={yearBounds.endString}
+                      />
+                      <span className="text-muted-foreground text-sm ml-auto">
+                        ({SCHEDULE_HOURS[period.scheduleType]}h/dia)
+                      </span>
+                      {!isFirstPeriod && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon"
+                          className="h-8 w-8"
+                          onClick={() => removeSchedulePeriod(period.id)}
+                          disabled={sortedSchedulePeriods.length <= 1}
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </Button>
+                      )}
+                    </div>
+                  );
+                })}
               </div>
             </div>
             </TabsContent>
@@ -670,7 +685,7 @@ export function SettingsDialog({
               Cancel·lar
             </Button>
           )}
-          <Button onClick={handleSave}>
+          <Button onClick={handleSave} disabled={!scheduleValidation.isValid}>
             {isOnboarding ? (onboardingStep < 3 ? 'Desar i continuar' : 'Desar i finalitzar') : 'Desar canvis'}
           </Button>
         </DialogFooter>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -35,7 +35,7 @@ export const DEFAULT_USER_CONFIG = {
       id: 'default-winter',
       startDate: `${DEFAULT_CALENDAR_YEAR}-01-01`,
       endDate: `${DEFAULT_CALENDAR_YEAR}-12-31`,
-      scheduleType: 'hivern' as const,
+      scheduleType: 'estiu' as const,
     },
   ],
   totalVacationDays: 25,


### PR DESCRIPTION
### Motivation
- Evitar que la primera franja horària pugui ser eliminada accidentalment tal com indica el requeriment `La primera franja no es pot eliminar mai`.
- Impedir l'edició del `startDate` quan aquest coincideix amb l'inici d'any perquè la franja arrel no es desancrei.
- Millorar la validesa del formulari per no permetre `onSave` quan falten dies per definir i fer-ho visible a l'usuari.

### Description
- Amagat el botó de `Trash2` per a la primera franja comprovant `isFirstPeriod` abans de renderitzar el `Button` en `SettingsDialog.tsx` (ja no apareix la icona de paperera a la primera franja).
- Afegit càlcul de `isYearStart` i `isFirstPeriod` i deshabilitat l'`Input` de `startDate` quan `isYearStart` amb un `title` explicatiu (`El dia 01/01 no es pot editar.`).
- Afegida una comprovació a `updateSchedulePeriod` que evita canviar el `startDate` si l'entrada és l'inici d'any (`yearStart`).
- A `handleSave` es fa servir `scheduleValidation` per bloquejar la gravació quan falten dies i es mostra un `toast.error` amb el recompte; el botó `Desar` també es deshabilita quan `!scheduleValidation.isValid`.
- Canviat el valor per defecte de la franja inicial a `DEFAULT_USER_CONFIG.schedulePeriods[0].scheduleType` de `'hivern'` a `'estiu'` a `src/lib/constants.ts`.

### Testing
- No s'han executat proves automatitzades per aquests canvis.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973fd9f778c8327a8689a70df81af60)