### PR TITLE
Replace “Pendent” legend color with “Cap de setmana”

### DIFF
--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -21,8 +21,8 @@ export function Legend() {
                 <span className="text-muted-foreground">Sense dades</span>
               </div>
               <div className="flex items-center gap-2">
-                <div className="w-4 h-4 rounded bg-[hsl(var(--status-pending))]" />
-                <span className="text-muted-foreground">Pendent</span>
+                <div className="w-4 h-4 rounded bg-[hsl(var(--status-weekend))]" />
+                <span className="text-muted-foreground">Cap de setmana</span>
               </div>
               <div className="flex items-center gap-2">
                 <div className="w-4 h-4 rounded bg-[hsl(var(--status-deficit))]" />
@@ -39,10 +39,6 @@ export function Legend() {
               <div className="flex items-center gap-2">
                 <div className="w-4 h-4 rounded bg-[hsl(var(--status-vacation))]" />
                 <span className="text-muted-foreground">Vacances</span>
-              </div>
-              <div className="flex items-center gap-2">
-                <div className="w-4 h-4 rounded bg-[hsl(var(--status-weekend))]" />
-                <span className="text-muted-foreground">Cap de setmana</span>
               </div>
             </div>
           </div>


### PR DESCRIPTION
### Motivation
- The legend should no longer show the "Pendent" color entry and instead place the "Cap de setmana" color in that position to match updated UI expectations.

### Description
- Replaced the `--status-pending` color entry with `--status-weekend` and label text "Cap de setmana" in `src/components/Legend.tsx`, and removed the duplicated weekend entry.

### Testing
- Attempted to run `npm install` to run the app/tests but the install failed with a registry `403` so no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974037118048327bc06c37741dad16e)