### PR TITLE
Add Control horari logo in header

### DIFF
--- a/public/control-horari-logo.svg
+++ b/public/control-horari-logo.svg
@@ -1,0 +1,15 @@
+<svg width="260" height="90" viewBox="0 0 260 90" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Control horari">
+  <defs>
+    <linearGradient id="sigmaGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F5DA8" />
+      <stop offset="100%" stop-color="#2E7AC4" />
+    </linearGradient>
+  </defs>
+  <rect width="260" height="90" fill="white" />
+  <text x="10" y="55" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="url(#sigmaGradient)">
+    ΣH
+  </text>
+  <text x="12" y="78" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="italic" fill="#6B7280">
+    Control horari
+  </text>
+</svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/button';
 import { Legend } from '@/components/Legend';
 import { StatusSummary } from '@/components/Summary/StatusSummary';
-import { Settings, Clock } from 'lucide-react';
+import { Settings } from 'lucide-react';
 import type { DayData, UserConfig } from '@/types';
 
 interface HeaderProps {
@@ -21,11 +21,12 @@ export function Header({ config, daysData, onOpenSettings }: HeaderProps) {
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:gap-6">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-primary rounded-lg">
-                <Clock className="w-6 h-6 text-primary-foreground" />
-              </div>
+              <img
+                src="/control-horari-logo.svg"
+                alt="Control horari"
+                className="h-12 w-auto"
+              />
               <div>
-                <h1 className="text-xl font-bold text-foreground">Control horari</h1>
                 <p className="text-sm text-muted-foreground">
                   {userName} · {config.calendarYear}
                 </p>


### PR DESCRIPTION
### Motivation
- Add a branded logo to the app header to improve visual identity.
- Replace the previous clock icon/title block with the new SVG while preserving the user name and calendar year context.

### Description
- Add the SVG asset at `public/control-horari-logo.svg` that contains the Control horari mark and text.
- Update `src/components/Header.tsx` to remove the `Clock` icon import and render the logo image via `<img src="/control-horari-logo.svg" alt="Control horari" />` in the header.
- Keep the existing user display (`{userName} · {config.calendarYear}`) and the compact `StatusSummary` intact.

### Testing
- Ran `npm install`, which produced `MaxListenersExceededWarning` warnings and did not complete reliably in this environment.
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which failed because `vite` was not found, so the app could not be launched for visual verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e5e0feb48327b4a9462b3f190bcc)