### PR TITLE
Fix logo asset path for GitHub deployment

### DIFF
--- a/src/assets/control-horari-logo.svg
+++ b/src/assets/control-horari-logo.svg
@@ -1,0 +1,15 @@
+<svg width="260" height="90" viewBox="0 0 260 90" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Control horari">
+  <defs>
+    <linearGradient id="sigmaGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F5DA8" />
+      <stop offset="100%" stop-color="#2E7AC4" />
+    </linearGradient>
+  </defs>
+  <rect width="260" height="90" fill="white" />
+  <text x="10" y="55" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" fill="url(#sigmaGradient)">
+    ΣH
+  </text>
+  <text x="12" y="78" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="italic" fill="#6B7280">
+    Control horari
+  </text>
+</svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@/components/ui/button';
 import { Legend } from '@/components/Legend';
 import { StatusSummary } from '@/components/Summary/StatusSummary';
-import { Settings, Clock } from 'lucide-react';
+import { Settings } from 'lucide-react';
+import controlHorariLogo from '@/assets/control-horari-logo.svg';
 import type { DayData, UserConfig } from '@/types';
 
 interface HeaderProps {
@@ -21,11 +22,12 @@ export function Header({ config, daysData, onOpenSettings }: HeaderProps) {
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:gap-6">
             <div className="flex items-center gap-3">
-              <div className="p-2 bg-primary rounded-lg">
-                <Clock className="w-6 h-6 text-primary-foreground" />
-              </div>
+              <img
+                src={controlHorariLogo}
+                alt="Control horari"
+                className="h-12 w-auto"
+              />
               <div>
-                <h1 className="text-xl font-bold text-foreground">Control horari</h1>
                 <p className="text-sm text-muted-foreground">
                   {userName} · {config.calendarYear}
                 </p>


### PR DESCRIPTION
### Motivation
- Ensure the Control horari logo loads correctly when the app is deployed to non-root base paths (e.g., GitHub Pages) by bundling it with the app assets and importing it instead of referencing a site-root path.

### Description
- Move `public/control-horari-logo.svg` into the bundled assets at `src/assets/control-horari-logo.svg` and keep the SVG content unchanged.
- Update `src/components/Header.tsx` to import the SVG (`import controlHorariLogo from '@/assets/control-horari-logo.svg'`) and render it via `<img src={controlHorariLogo} ... />`, removing the previous `Clock` icon and root-path reference.
- No AGENTS.md skills were required or used for this change.

### Testing
- No automated tests were run for this change in this environment.
- Previous automated attempts to run `npm install` and `npm run dev` in the earlier rollout failed due to environment/tooling issues (missing `vite`), so a full build/dev verification was not performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e5e0feb48327b4a9462b3f190bcc)