### PR TITLE
Tighten logo spacing and stack user/year

### DIFF
--- a/src/assets/control-horari-logo.svg
+++ b/src/assets/control-horari-logo.svg
@@ -1,0 +1,14 @@
+<svg width="200" height="90" viewBox="0 0 200 90" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Control horari">
+  <defs>
+    <linearGradient id="sigmaGradient" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1F5DA8" />
+      <stop offset="100%" stop-color="#2E7AC4" />
+    </linearGradient>
+  </defs>
+  <text x="100" y="55" font-family="Arial, Helvetica, sans-serif" font-size="56" font-weight="700" text-anchor="middle" fill="url(#sigmaGradient)">
+    ΣH
+  </text>
+  <text x="100" y="78" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="italic" text-anchor="middle" fill="#6B7280">
+    Control horari
+  </text>
+</svg>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@/components/ui/button';
 import { Legend } from '@/components/Legend';
 import { StatusSummary } from '@/components/Summary/StatusSummary';
-import { Settings, Clock } from 'lucide-react';
+import { Settings } from 'lucide-react';
+import controlHorariLogo from '@/assets/control-horari-logo.svg';
 import type { DayData, UserConfig } from '@/types';
 
 interface HeaderProps {
@@ -20,14 +21,16 @@ export function Header({ config, daysData, onOpenSettings }: HeaderProps) {
       <div className="container mx-auto px-4 py-4">
         <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
           <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:gap-6">
-            <div className="flex items-center gap-3">
-              <div className="p-2 bg-primary rounded-lg">
-                <Clock className="w-6 h-6 text-primary-foreground" />
-              </div>
+            <div className="flex items-center gap-4">
+              <img
+                src={controlHorariLogo}
+                alt="Control horari"
+                className="h-12 w-auto"
+              />
               <div>
-                <h1 className="text-xl font-bold text-foreground">Control horari</h1>
-                <p className="text-sm text-muted-foreground">
-                  {userName} · {config.calendarYear}
+                <p className="text-sm text-muted-foreground text-right leading-tight">
+                  <span className="block">{userName}</span>
+                  <span className="block">{config.calendarYear}</span>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Remove the large white padding on the sides of the bundled logo so it aligns tightly with the header.
- Place the user's name and calendar year to the right of the logo with the name above the year for a more compact, readable layout.
- Replace the previous clock icon/title layout with the bundled SVG to ensure consistent rendering across deployments.

### Description
- Updated `src/assets/control-horari-logo.svg` to remove the white background rectangle, reduce the overall width, and center the text elements (`ΣH` and `Control horari`) within a `200x90` viewBox. 
- Imported the bundled SVG in `src/components/Header.tsx` as `controlHorariLogo` and rendered it via an `<img>` instead of the previous `Clock` icon. 
- Adjusted header layout spacing and swapped the single-line user/year text for stacked lines using `text-right` and two `block` spans so the name appears above the year. 
- Tuned spacing classes (`gap-4`, `leading-tight`) to keep the logo and stacked user info visually compact.

### Testing
- No automated tests were run for this change in this environment. 
- Local build and runtime verification were not requested and therefore not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974e5e0feb48327b4a9462b3f190bcc)