### PR TITLE
Update app name to 'Σ Horari', bump version to 1.1, and add GitHub author link

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -6,7 +6,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Badge } from '@/components/ui/badge';
-import { X, Plus, Download, Upload, Trash2, AlertTriangle, AlertCircle, Info } from 'lucide-react';
+import { X, Plus, Download, Upload, Trash2, AlertTriangle, AlertCircle, Info, Github } from 'lucide-react';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog';
 import type { UserConfig, DayType, SchedulePeriod, ScheduleType } from '@/types';
 import { APP_INFO, DAYS_OF_WEEK, DAY_NAMES_CA, MONTH_NAMES_CA, SCHEDULE_HOURS } from '@/lib/constants';
@@ -658,7 +658,18 @@ export function SettingsDialog({
               </div>
               <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border pb-3">
                 <dt className="text-muted-foreground">Autor</dt>
-                <dd className="font-medium text-right">{APP_INFO.author}</dd>
+                <dd className="flex items-center gap-2 font-medium text-right">
+                  <span>{APP_INFO.author}</span>
+                  <a
+                    href="https://github.com/rbarrachina"
+                    className="text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label="Perfil de Github de Rafa Barrachina"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    <Github className="h-4 w-4" />
+                  </a>
+                </dd>
               </div>
               <div className="flex flex-wrap items-center justify-between gap-2 border-b border-border pb-3">
                 <dt className="text-muted-foreground">Llicència</dt>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -73,9 +73,9 @@ export const MAX_FLEXIBILITY_HOURS = 25;
 export const MIN_WEEKLY_SURPLUS_FOR_FLEXIBILITY = 0.5; // 30 minutes
 
 export const APP_INFO = {
-  name: 'Control horari Educació',
+  name: 'Σ Horari',
   author: 'Rafa Barrachina',
   license: 'Apache License 2.0',
   year: 2026,
-  version: '1.0',
+  version: '1.1',
 };


### PR DESCRIPTION
### Motivation
- Surface the intended app branding and authorship link in the UI by changing the displayed program name, bumping the version, and exposing a clickable GitHub profile for the author.

### Description
- Updated `APP_INFO` in `src/lib/constants.ts` to set `name: 'Σ Horari'` and `version: '1.1'`, and added a GitHub profile link and `Github` icon import in `src/components/Settings/SettingsDialog.tsx` to display an author link next to the author name.

### Testing
- Attempted to install dependencies with `npm install` to run the app/build, but the install failed with a `403 Forbidden` from the registry so automated build/testing could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69766c5ed2608327a273a0e9ed5c47a6)