### PR TITLE
Update Vite `base` for GitHub Pages to new repo name

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { componentTagger } from "lovable-tagger";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => ({
-  base: mode === "gh" ? "/control-horari-educacio/" : "/",
+  base: mode === "gh" ? "/sigma-horari/" : "/",
   server: {
     host: "::",
     port: 8080,


### PR DESCRIPTION
### Motivation
- The repository was renamed and the GitHub Pages site URL changed, so the Vite `base` path must match the new repo slug to serve assets correctly at `https://rbarrachina.github.io/sigma-horari/`.

### Description
- Update `vite.config.ts` to set `base: mode === "gh" ? "/sigma-horari/" : "/"` so builds run with the correct GitHub Pages base path.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69767410c8748327939eba50466a3221)