### PR TITLE
Split AP total into hours and minutes inputs in Settings

### DIFF
--- a/src/components/Settings/SettingsDialog.tsx
+++ b/src/components/Settings/SettingsDialog.tsx
@@ -21,6 +21,8 @@ const ONBOARDING_TABS = {
   3: 'holidays',
 } as const;
 
+const MAX_AP_HOURS = 500;
+
 const SETTINGS_TABS = [
   { value: 'personal', label: 'Personal' },
   { value: 'schedule', label: 'Horari' },
@@ -49,6 +51,8 @@ export function SettingsDialog({
   onOnboardingStepChange,
 }: SettingsDialogProps) {
   const [localConfig, setLocalConfig] = useState<UserConfig>(config);
+  const [apTotalHours, setApTotalHours] = useState(0);
+  const [apTotalMinutes, setApTotalMinutes] = useState(0);
   const [newHoliday, setNewHoliday] = useState('');
   const [activeTab, setActiveTab] = useState<'personal' | 'schedule' | 'holidays' | 'data' | 'authorship'>('personal');
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -65,6 +69,9 @@ export function SettingsDialog({
 
   useEffect(() => {
     setLocalConfig(config);
+    const totalMinutes = Math.round(config.totalAPHours * 60);
+    setApTotalHours(Math.floor(totalMinutes / 60));
+    setApTotalMinutes(totalMinutes % 60);
   }, [config]);
 
   useEffect(() => {
@@ -171,6 +178,26 @@ export function SettingsDialog({
         },
       },
     }));
+  };
+
+  const updateAPTotalHours = (nextHours: number, nextMinutes: number) => {
+    const safeHours = Number.isNaN(nextHours) ? 0 : Math.max(0, nextHours);
+    const safeMinutes = Number.isNaN(nextMinutes) ? 0 : Math.max(0, nextMinutes);
+    let adjustedHours = safeHours;
+    let adjustedMinutes = Math.min(safeMinutes, 59);
+
+    if (adjustedHours >= MAX_AP_HOURS) {
+      adjustedHours = MAX_AP_HOURS;
+      adjustedMinutes = 0;
+    }
+
+    if (adjustedHours + adjustedMinutes / 60 > MAX_AP_HOURS) {
+      adjustedMinutes = 0;
+    }
+
+    setApTotalHours(adjustedHours);
+    setApTotalMinutes(adjustedMinutes);
+    setLocalConfig(prev => ({ ...prev, totalAPHours: adjustedHours + adjustedMinutes / 60 }));
   };
 
   const updateSchedulePeriod = (id: string, field: 'startDate' | 'endDate' | 'scheduleType', value: string) => {
@@ -388,13 +415,39 @@ export function SettingsDialog({
                 />
               </div>
               <div className="space-y-2">
-                <Label htmlFor="apHours">Hores d'AP totals</Label>
-                <Input
-                  id="apHours"
-                  type="number"
-                  value={localConfig.totalAPHours}
-                  onChange={(e) => setLocalConfig(prev => ({ ...prev, totalAPHours: parseInt(e.target.value) || 0 }))}
-                />
+                <Label>Hores d'AP totals</Label>
+                <div className="grid grid-cols-2 gap-3">
+                  <div className="space-y-1">
+                    <Label htmlFor="apHours" className="text-xs text-muted-foreground">Hores</Label>
+                    <Input
+                      id="apHours"
+                      type="number"
+                      min={0}
+                      max={MAX_AP_HOURS}
+                      step="1"
+                      value={apTotalHours}
+                      onChange={(e) => {
+                        const nextHours = parseInt(e.target.value) || 0;
+                        updateAPTotalHours(nextHours, apTotalMinutes);
+                      }}
+                    />
+                  </div>
+                  <div className="space-y-1">
+                    <Label htmlFor="apMinutes" className="text-xs text-muted-foreground">Minuts</Label>
+                    <Input
+                      id="apMinutes"
+                      type="number"
+                      min={0}
+                      max={apTotalHours >= MAX_AP_HOURS ? 0 : 59}
+                      step="1"
+                      value={apTotalMinutes}
+                      onChange={(e) => {
+                        const nextMinutes = parseInt(e.target.value) || 0;
+                        updateAPTotalHours(apTotalHours, nextMinutes);
+                      }}
+                    />
+                  </div>
+                </div>
               </div>
             </div>
 


### PR DESCRIPTION
### Motivation
- Users need to set AP (assumpte propi) totals with hours and minutes rather than a single integer hours field.
- The stored `totalAPHours` must remain a single numeric value (hours as decimal) and be capped to a safe maximum.

### Description
- Add `MAX_AP_HOURS` constant and two local state fields `apTotalHours` and `apTotalMinutes` to `SettingsDialog` to represent the AP total as hours + minutes.
- Initialize hours/minutes from `config.totalAPHours` in `useEffect` and keep the `localConfig.totalAPHours` synced as `hours + minutes/60`.
- Implement `updateAPTotalHours` to normalize inputs, enforce minute limits, and cap the total to `MAX_AP_HOURS`.
- Replace the single AP input field with two number inputs in the Personal settings UI for `Hores` and `Minuts`, including UI caps that disable minutes when the hours value is at the maximum.

### Testing
- `npm install` was attempted but failed with a registry 403 error when fetching `@testing-library/jest-dom`, so dependencies could not be installed and no build was performed.
- `npm run dev` was attempted but failed because `vite` was not available due to missing dependencies.
- No automated unit or integration tests were executed because the install step failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697676bda5248327831a48889f6c938e)