### PR TITLE
Set default summer/winter schedule periods

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -32,8 +32,44 @@ export const DEFAULT_USER_CONFIG = {
   },
   schedulePeriods: [
     {
-      id: 'default-winter',
+      id: 'default-1',
       startDate: `${DEFAULT_CALENDAR_YEAR}-01-01`,
+      endDate: `${DEFAULT_CALENDAR_YEAR}-01-10`,
+      scheduleType: 'estiu' as const,
+    },
+    {
+      id: 'default-2',
+      startDate: `${DEFAULT_CALENDAR_YEAR}-01-11`,
+      endDate: `${DEFAULT_CALENDAR_YEAR}-03-29`,
+      scheduleType: 'hivern' as const,
+    },
+    {
+      id: 'default-3',
+      startDate: `${DEFAULT_CALENDAR_YEAR}-03-30`,
+      endDate: `${DEFAULT_CALENDAR_YEAR}-04-06`,
+      scheduleType: 'estiu' as const,
+    },
+    {
+      id: 'default-4',
+      startDate: `${DEFAULT_CALENDAR_YEAR}-04-07`,
+      endDate: `${DEFAULT_CALENDAR_YEAR}-05-31`,
+      scheduleType: 'hivern' as const,
+    },
+    {
+      id: 'default-5',
+      startDate: `${DEFAULT_CALENDAR_YEAR}-06-01`,
+      endDate: `${DEFAULT_CALENDAR_YEAR}-09-30`,
+      scheduleType: 'estiu' as const,
+    },
+    {
+      id: 'default-6',
+      startDate: `${DEFAULT_CALENDAR_YEAR}-10-01`,
+      endDate: `${DEFAULT_CALENDAR_YEAR}-12-14`,
+      scheduleType: 'hivern' as const,
+    },
+    {
+      id: 'default-7',
+      startDate: `${DEFAULT_CALENDAR_YEAR}-12-15`,
       endDate: `${DEFAULT_CALENDAR_YEAR}-12-31`,
       scheduleType: 'estiu' as const,
     },


### PR DESCRIPTION
### Motivation
- Provide a sensible default summer/winter split so the calendar shows the seasonal periods in Settings by default while keeping them editable by the user.

### Description
- Update `DEFAULT_USER_CONFIG.schedulePeriods` in `src/lib/constants.ts` to replace the single full-year period with seven default periods (`default-1`..`default-7`) that partition the year and alternate `scheduleType` between `estiu` and `hivern`.
- Use `DEFAULT_CALENDAR_YEAR` in the period `startDate`/`endDate` template strings so the ranges remain relative to the configured year.

### Testing
- Attempted to install dependencies with `npm install`, but it failed due to a `403 Forbidden` error from the npm registry so the app could not be built or run.
- No automated test suites (`vitest`) were executed because the dependency installation failed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69767b5b610c83278585e4b45f57d017)