### PR TITLE
Normalize rounding for day difference display

### DIFF
--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/utils';
 import type { DayData, UserConfig } from '@/types';
-import { calculateDayWorkedHours, isWeekend, isHoliday, getTheoreticalHoursForDate, getDayTypeForDate } from '@/lib/timeCalculations';
+import { calculateDayWorkedHours, isWeekend, isHoliday, getTheoreticalHoursForDate, getDayTypeForDate, normalizeHoursDifference } from '@/lib/timeCalculations';
 import { format } from 'date-fns';
 import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check, MoreHorizontal } from 'lucide-react';
 
@@ -42,7 +42,8 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isInCalenda
           ? (dayData.flexHours || 0)
           : (dayData.otherHours || 0);
       const totalWorked = worked + extraHours;
-      if (dayData.requestStatus === 'aprovat' && totalWorked >= theoretical) {
+      const difference = normalizeHoursDifference(totalWorked - theoretical);
+      if (dayData.requestStatus === 'aprovat' && difference >= 0) {
         return 'bg-[hsl(var(--status-complete))] text-[hsl(var(--status-complete-foreground))]';
       }
       return 'bg-[hsl(var(--status-deficit))] text-[hsl(var(--status-deficit-foreground))]';
@@ -59,7 +60,8 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isInCalenda
     const worked = calculateDayWorkedHours(dayData);
     const theoretical = getTheoreticalHoursForDate(date, config);
     
-    if (worked >= theoretical) {
+    const difference = normalizeHoursDifference(worked - theoretical);
+    if (difference >= 0) {
       return 'bg-[hsl(var(--status-complete))] text-[hsl(var(--status-complete-foreground))]';
     }
     return 'bg-[hsl(var(--status-deficit))] text-[hsl(var(--status-deficit-foreground))]';

--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import type { DayData, UserConfig, DayStatus, RequestStatus } from '@/types';
-import { getTheoreticalHoursForDate, getDayTypeForDate, calculateWorkedHours, isHoliday, formatHoursToTime, parseTimeToHours } from '@/lib/timeCalculations';
+import { getTheoreticalHoursForDate, getDayTypeForDate, calculateWorkedHours, isHoliday, formatHoursToTime, parseTimeToHours, normalizeHoursDifference } from '@/lib/timeCalculations';
 import { DAY_NAMES_CA, MAX_FLEXIBILITY_HOURS, MONTH_NAMES_CA } from '@/lib/constants';
 import { Home, Building2, Plus, Trash2 } from 'lucide-react';
 
@@ -137,9 +137,7 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
       ? actualWorkedHours + absenceHoursDecimal
       : actualWorkedHours;
   
-  const rawDifference = totalWorkedHours - theoreticalHours;
-  const roundedDifference = Math.round(rawDifference * 60) / 60;
-  const difference = Math.abs(roundedDifference) < 1 / 60 ? 0 : roundedDifference;
+  const difference = normalizeHoursDifference(totalWorkedHours - theoreticalHours);
   const holiday = isHoliday(date, config.holidays);
 
   const getDayName = () => {

--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -137,7 +137,9 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
       ? actualWorkedHours + absenceHoursDecimal
       : actualWorkedHours;
   
-  const difference = totalWorkedHours - theoreticalHours;
+  const rawDifference = totalWorkedHours - theoreticalHours;
+  const roundedDifference = Math.round(rawDifference * 60) / 60;
+  const difference = Math.abs(roundedDifference) < 1 / 60 ? 0 : roundedDifference;
   const holiday = isHoliday(date, config.holidays);
 
   const getDayName = () => {

--- a/src/lib/timeCalculations.ts
+++ b/src/lib/timeCalculations.ts
@@ -141,6 +141,11 @@ export function formatHoursDisplay(hours: number): string {
   return `${sign}${h}h ${m}min`;
 }
 
+export function normalizeHoursDifference(hours: number): number {
+  const rounded = Math.round(hours * 60) / 60;
+  return Math.abs(rounded) < 1 / 60 ? 0 : rounded;
+}
+
 export function formatHoursMinutes(hours: number): string {
   const totalMinutes = Math.round(Math.abs(hours) * 60);
   const h = Math.floor(totalMinutes / 60);


### PR DESCRIPTION
### Motivation
- Small floating-point residuals could produce a tiny non-zero `difference` (e.g. -0.0001h) that was rendered with a negative sign and shown in the deficit color even when it should appear as `0:00`.

### Description
- Round the raw difference to the nearest minute by computing `roundedDifference = Math.round(rawDifference * 60) / 60` and treat values smaller than one minute as zero. 
- Apply this logic in `src/components/Calendar/DayDetailDialog.tsx` so the displayed `difference` is normalized before formatting and color selection.

### Testing
- Attempted to install dependencies with `npm install`, but the install failed due to a `403` from the npm registry, so the UI and automated tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768e176dd48327a65a2e448671b18a)