### PR TITLE
Improve status-complete contrast

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -74,8 +74,8 @@ All colors MUST be HSL.
     --status-pending-foreground: 222 47% 11%;
     --status-deficit: 45 93% 47%;
     --status-deficit-foreground: 222 47% 11%;
-    --status-complete: 142 71% 45%;
-    --status-complete-foreground: 210 40% 98%;
+    --status-complete: 142 72% 55%;
+    --status-complete-foreground: 222 47% 11%;
     --status-holiday: 280 64% 60%;
     --status-holiday-foreground: 0 0% 100%;
     --status-vacation: 199 89% 48%;


### PR DESCRIPTION
### Motivation
- The green used for the "complete" status was too muted against dark gray surfaces and needed better contrast while remaining consistent with the app palette.

### Description
- Updated the `--status-complete` and `--status-complete-foreground` color variables in `src/index.css` to a brighter green and a darker foreground for improved readability.

### Testing
- No automated tests were run; an attempt to install dependencies (`npm install`) failed with an `ENOTEMPTY` error and `npm run dev` could not start (`vite` not found), so visual verification could not be performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977cbdf53dc8327a24086b96dbd772d)