### PR TITLE
Cap daily worked hours at 9h30

### DIFF
--- a/src/components/Calendar/CalendarDay.tsx
+++ b/src/components/Calendar/CalendarDay.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/utils';
 import type { DayData, UserConfig } from '@/types';
-import { calculateDayWorkedHours, isWeekend, isHoliday, getTheoreticalHoursForDate, getDayTypeForDate, normalizeHoursDifference } from '@/lib/timeCalculations';
+import { calculateTotalWorkedHours, isWeekend, isHoliday, getTheoreticalHoursForDate, getDayTypeForDate, normalizeHoursDifference } from '@/lib/timeCalculations';
 import { format } from 'date-fns';
 import { Home, Building2, Plane, Clock, Sparkles, Calendar, Check, MoreHorizontal } from 'lucide-react';
 
@@ -34,14 +34,8 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isInCalenda
     
     // AP or FX with approval status
     if (dayData?.dayStatus === 'assumpte_propi' || dayData?.dayStatus === 'flexibilitat' || dayData?.dayStatus === 'altres') {
-      const worked = calculateDayWorkedHours(dayData);
       const theoretical = getTheoreticalHoursForDate(date, config);
-      const extraHours = dayData.dayStatus === 'assumpte_propi'
-        ? (dayData.apHours || 0)
-        : dayData.dayStatus === 'flexibilitat'
-          ? (dayData.flexHours || 0)
-          : (dayData.otherHours || 0);
-      const totalWorked = worked + extraHours;
+      const totalWorked = calculateTotalWorkedHours(dayData);
       const difference = normalizeHoursDifference(totalWorked - theoretical);
       if (dayData.requestStatus === 'aprovat' && difference >= 0) {
         return 'bg-[hsl(var(--status-complete))] text-[hsl(var(--status-complete-foreground))]';
@@ -57,7 +51,7 @@ export function CalendarDay({ date, dayData, config, isCurrentMonth, isInCalenda
       return 'bg-[hsl(var(--status-weekday-empty))] text-[hsl(var(--status-pending-foreground))]';
     }
     
-    const worked = calculateDayWorkedHours(dayData);
+    const worked = calculateTotalWorkedHours(dayData);
     const theoretical = getTheoreticalHoursForDate(date, config);
     
     const difference = normalizeHoursDifference(worked - theoretical);

--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -8,7 +8,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Checkbox } from '@/components/ui/checkbox';
 import { Badge } from '@/components/ui/badge';
 import type { DayData, UserConfig, DayStatus, RequestStatus } from '@/types';
-import { getTheoreticalHoursForDate, getDayTypeForDate, calculateWorkedHours, isHoliday, formatHoursToTime, parseTimeToHours, normalizeHoursDifference } from '@/lib/timeCalculations';
+import { getTheoreticalHoursForDate, getDayTypeForDate, calculateWorkedHours, isHoliday, formatHoursToTime, parseTimeToHours, normalizeHoursDifference, capDailyHours } from '@/lib/timeCalculations';
 import { DAY_NAMES_CA, MAX_FLEXIBILITY_HOURS, MONTH_NAMES_CA } from '@/lib/constants';
 import { Home, Building2, Plus, Trash2 } from 'lucide-react';
 
@@ -131,11 +131,14 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
   const getFlexMinutesLimit = (hoursValue: number) => (hoursValue >= maxFlexHoursInt ? maxFlexMinutes : 59);
   
   // Total worked hours = actual worked + AP/FX hours (if applicable)
-  const totalWorkedHours = absenceType === 'vacances' 
+  const rawTotalWorkedHours = absenceType === 'vacances' 
     ? theoreticalHours  // Vacances counts as full day
     : (absenceType === 'assumpte_propi' || absenceType === 'flexibilitat' || absenceType === 'altres')
       ? actualWorkedHours + absenceHoursDecimal
       : actualWorkedHours;
+  const totalWorkedHours = absenceType === 'vacances'
+    ? rawTotalWorkedHours
+    : capDailyHours(rawTotalWorkedHours);
   
   const difference = normalizeHoursDifference(totalWorkedHours - theoreticalHours);
   const holiday = isHoliday(date, config.holidays);

--- a/src/components/Calendar/WeeklySummaryDialog.tsx
+++ b/src/components/Calendar/WeeklySummaryDialog.tsx
@@ -8,6 +8,8 @@ import {
   getTheoreticalHoursForDate, 
   getDayTypeForDate, 
   calculateDayWorkedHours, 
+  calculateTotalWorkedHours,
+  capDailyHours,
   isHoliday, 
   isWeekend,
   formatHoursDisplay,
@@ -62,15 +64,7 @@ export function WeeklySummaryDialog({
     const theoretical = getTheoreticalHoursForDate(day, config);
     totalTheoretical += theoretical;
     
-    if (dayData?.dayStatus === 'assumpte_propi') {
-      totalWorked += (dayData.apHours || 0) + calculateDayWorkedHours(dayData);
-    } else if (dayData?.dayStatus === 'flexibilitat') {
-      totalWorked += (dayData.flexHours || 0) + calculateDayWorkedHours(dayData);
-    } else if (dayData?.dayStatus === 'altres') {
-      totalWorked += (dayData.otherHours || 0) + calculateDayWorkedHours(dayData);
-    } else {
-      totalWorked += calculateDayWorkedHours(dayData);
-    }
+    totalWorked += calculateTotalWorkedHours(dayData);
   }
 
   const difference = totalWorked - totalTheoretical;
@@ -158,7 +152,7 @@ export function WeeklySummaryDialog({
                 : dayData?.dayStatus === 'altres'
                   ? (dayData.otherHours || 0)
                   : 0;
-            const worked = baseWorked + extraHours;
+            const worked = capDailyHours(baseWorked + extraHours);
             const excludedFromTotals = holiday || dayData?.dayStatus === 'vacances';
             const summaryTheoretical = excludedFromTotals ? 0 : theoretical;
             const summaryWorked = excludedFromTotals ? 0 : worked;

--- a/src/components/Calendar/WeeklySummaryIcon.tsx
+++ b/src/components/Calendar/WeeklySummaryIcon.tsx
@@ -1,6 +1,6 @@
 import { cn } from '@/lib/utils';
 import type { DayData, UserConfig } from '@/types';
-import { isWeekend, isHoliday, calculateDayWorkedHours, getTheoreticalHoursForDate } from '@/lib/timeCalculations';
+import { isWeekend, isHoliday, calculateTotalWorkedHours, getTheoreticalHoursForDate } from '@/lib/timeCalculations';
 import { format, eachDayOfInterval } from 'date-fns';
 import { CheckCircle, AlertCircle, XCircle } from 'lucide-react';
 
@@ -38,15 +38,7 @@ export function WeeklySummaryIcon({ weekStart, weekEnd, daysData, config, onClic
       const theoretical = getTheoreticalHoursForDate(day, config);
       totalTheoretical += theoretical;
 
-      if (dayData?.dayStatus === 'assumpte_propi') {
-        totalWorked += (dayData.apHours || 0) + calculateDayWorkedHours(dayData);
-      } else if (dayData?.dayStatus === 'flexibilitat') {
-        totalWorked += (dayData.flexHours || 0) + calculateDayWorkedHours(dayData);
-      } else if (dayData?.dayStatus === 'altres') {
-        totalWorked += (dayData.otherHours || 0) + calculateDayWorkedHours(dayData);
-      } else {
-        totalWorked += calculateDayWorkedHours(dayData);
-      }
+      totalWorked += calculateTotalWorkedHours(dayData);
     }
     
     if (!dayData) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -107,6 +107,7 @@ export const MONTH_NAMES_CA = [
 
 export const MAX_FLEXIBILITY_HOURS = 25;
 export const MIN_WEEKLY_SURPLUS_FOR_FLEXIBILITY = 0.5; // 30 minutes
+export const MAX_DAILY_WORK_HOURS = 9.5;
 
 export const APP_INFO = {
   name: 'Σ Horari',


### PR DESCRIPTION
### Motivation
- Enforce a maximum of 9 hours 30 minutes per calendar day so daily totals and weekly summaries never count more than the allowed daily maximum.

### Description
- Added a new constant `MAX_DAILY_WORK_HOURS = 9.5` in `src/lib/constants.ts` to represent the daily cap.
- Implemented `capDailyHours` and `calculateTotalWorkedHours` in `src/lib/timeCalculations.ts` to compute per-day totals and apply the cap.
- Replaced direct per-day summations with `calculateTotalWorkedHours` and applied `capDailyHours` where appropriate in `src/components/Calendar/CalendarDay.tsx`, `src/components/Calendar/WeeklySummaryIcon.tsx`, `src/components/Calendar/WeeklySummaryDialog.tsx`, and `src/components/Calendar/DayDetailDialog.tsx` so UI and summaries respect the 9h30 limit.

### Testing
- Attempted to install dependencies (`npm install`) and run tests, but `npm install` failed with a 403 from the npm registry so automated tests (`vitest`) were not run.
- Changes were staged and committed locally (`git commit`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977dc96240c83279f8a26e1d8562721)