### PR TITLE
Adjust `--status-complete` green to intermediate tone

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -74,7 +74,7 @@ All colors MUST be HSL.
     --status-pending-foreground: 222 47% 11%;
     --status-deficit: 45 93% 47%;
     --status-deficit-foreground: 222 47% 11%;
-    --status-complete: 142 45% 35%;
+    --status-complete: 142 50% 42%;
     --status-complete-foreground: 210 40% 98%;
     --status-holiday: 280 64% 60%;
     --status-holiday-foreground: 0 0% 100%;


### PR DESCRIPTION
### Motivation
- Provide an intermediate green for the `status-complete` color so it is neither too fluorescent nor too dark, per visual tuning of status tones.

### Description
- Updated the CSS variable `--status-complete` in `src/index.css` from `142 45% 35%` to `142 50% 42%` to shift the green to a more balanced tone.

### Testing
- Attempted to run `npm install` to build/validate the change but it failed with a `403 Forbidden` from the registry, so no automated build or test was executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977e0548b5c8327a1b24353e14fc814)