### PR TITLE
Emphasize day summary text

### DIFF
--- a/src/components/Calendar/DayDetailDialog.tsx
+++ b/src/components/Calendar/DayDetailDialog.tsx
@@ -504,7 +504,7 @@ export function DayDetailDialog({ date, dayData, config, requestedVacationDays, 
 
           {/* Summary */}
           <div className="p-4 bg-muted rounded-lg">
-            <div className="text-sm space-y-1">
+            <div className="text-base font-semibold space-y-1">
               <p>Hores totals: <strong>{formatHoursMinutes(totalWorkedHours)}</strong></p>
               <p className={difference >= 0 ? 'text-[hsl(var(--status-complete))]' : 'text-[hsl(var(--status-deficit))]'}>
                 Diferència: <strong>{difference >= 0 ? '+' : '-'}{formatHoursMinutes(difference)}</strong>


### PR DESCRIPTION
### Motivation
- Make the day summary more readable by increasing its font size and weight.

### Description
- In `src/components/Calendar/DayDetailDialog.tsx` replace `className="text-sm space-y-1"` with `className="text-base font-semibold space-y-1"` to make the summary text slightly larger and bold.

### Testing
- Attempted to run `npm install` to validate and run automated tests but it failed with a `403 Forbidden` error, so no tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6977e64e28748327bc48180a3e3d26e3)