### PR TITLE
Add final period to Control horari logo text

### DIFF
--- a/public/control-horari-logo.svg
+++ b/public/control-horari-logo.svg
@@ -10,6 +10,6 @@
     ΣH
   </text>
   <text x="12" y="78" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="italic" fill="#6B7280">
-    Control horari
+    Control horari.
   </text>
 </svg>

--- a/src/assets/control-horari-logo.svg
+++ b/src/assets/control-horari-logo.svg
@@ -9,6 +9,6 @@
     ΣH
   </text>
   <text x="100" y="78" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="italic" text-anchor="middle" fill="#6B7280">
-    Control horari.
+    . Control horari.
   </text>
 </svg>

--- a/src/assets/control-horari-logo.svg
+++ b/src/assets/control-horari-logo.svg
@@ -9,6 +9,6 @@
     ΣH
   </text>
   <text x="100" y="78" font-family="Arial, Helvetica, sans-serif" font-size="20" font-style="italic" text-anchor="middle" fill="#6B7280">
-    Control horari
+    Control horari.
   </text>
 </svg>


### PR DESCRIPTION
Summary
- add a period to the "Control horari" text used in the logo as requested

Testing
- Not run (not requested)